### PR TITLE
[TRC-164] 통계 수정

### DIFF
--- a/src/features/statistics/UserRankHeader.tsx
+++ b/src/features/statistics/UserRankHeader.tsx
@@ -14,14 +14,14 @@ const UserRankHeader = ({ className }: Props) => {
       {/* 닉네임 (빈 공간) */}
       <div className="flex-1 min-w-0" />
 
-      {/* 전적 */}
-      <div className="flex-shrink-0 w-32 text-center">
-        <span className="text-sm font-medium text-primary2">전적</span>
-      </div>
-
       {/* KDA */}
       <div className="flex-shrink-0 w-20 text-center">
         <span className="text-sm font-medium text-primary2">KDA</span>
+      </div>
+
+      {/* 전적 */}
+      <div className="flex-shrink-0 w-32 text-center">
+        <span className="text-sm font-medium text-primary2">전적</span>
       </div>
 
       {/* 승률 */}

--- a/src/features/statistics/UserRankHeader.tsx
+++ b/src/features/statistics/UserRankHeader.tsx
@@ -1,8 +1,19 @@
+type SortBy = "totalGames" | "winRate";
+type SortOrder = "asc" | "desc";
+
 interface Props {
   className?: string;
+  sortBy: SortBy;
+  sortOrder: SortOrder;
+  onSort: (column: SortBy) => void;
 }
 
-const UserRankHeader = ({ className }: Props) => {
+const UserRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => {
+  const getSortIndicator = (column: SortBy) => {
+    if (sortBy !== column) return null;
+    return sortOrder === "asc" ? " ▲" : " ▼";
+  };
+
   return (
     <div className={`hidden md:flex items-center gap-3 px-3 py-2 ${className || ""}`}>
       {/* 순위 (빈 공간) */}
@@ -21,12 +32,24 @@ const UserRankHeader = ({ className }: Props) => {
 
       {/* 전적 */}
       <div className="flex-shrink-0 w-32 text-center">
-        <span className="text-sm font-medium text-primary2">전적</span>
+        <button
+          type="button"
+          onClick={() => onSort("totalGames")}
+          className="text-sm font-medium text-primary2 hover:text-primary1 transition-colors cursor-pointer"
+        >
+          전적{getSortIndicator("totalGames")}
+        </button>
       </div>
 
       {/* 승률 */}
       <div className="flex-shrink-0 w-20 text-center">
-        <span className="text-sm font-medium text-primary2">승률</span>
+        <button
+          type="button"
+          onClick={() => onSort("winRate")}
+          className="text-sm font-medium text-primary2 hover:text-primary1 transition-colors cursor-pointer"
+        >
+          승률{getSortIndicator("winRate")}
+        </button>
       </div>
     </div>
   );

--- a/src/features/statistics/UserRankItem.tsx
+++ b/src/features/statistics/UserRankItem.tsx
@@ -85,16 +85,16 @@ const UserRankItem = ({
           </div>
         </div>
 
-        {/* 전적 (n전 n승 n패) */}
-        <div className="flex-shrink-0 w-32 text-center">
-          <span className="text-sm text-primary2">
-            {formatNumber(totalGames)}전 {formatNumber(wins)}승 {formatNumber(losses)}패
-          </span>
-        </div>
-
         {/* KDA */}
         <div className="flex-shrink-0 w-20 text-center">
-          <span className="text-sm text-primary1">{kda}</span>
+          <span className="text-sm text-primary2">{kda}</span>
+        </div>
+
+        {/* 전적 (n전 n승 n패) */}
+        <div className="flex-shrink-0 w-32 text-center">
+          <span className="text-sm text-primary1">
+            {formatNumber(totalGames)}전 {formatNumber(wins)}승 {formatNumber(losses)}패
+          </span>
         </div>
 
         {/* 승률 */}
@@ -121,7 +121,7 @@ const UserRankItem = ({
           />
         </div>
 
-        {/* 닉네임 + 전적 */}
+        {/* 닉네임 + KDA */}
         <div className="flex-1 min-w-0">
           <button
             type="button"
@@ -134,14 +134,14 @@ const UserRankItem = ({
           >
             {riotName}
           </button>
-          <div className="text-xs text-primary2">
-            {formatNumber(totalGames)}전 {formatNumber(wins)}승 {formatNumber(losses)}패
-          </div>
+          <div className="text-xs text-primary2">{kda}</div>
         </div>
 
-        {/* KDA + 승률 */}
+        {/* 전적 + 승률 */}
         <div className="flex-shrink-0 text-right">
-          <div className="text-sm text-primary1">{kda}</div>
+          <div className="text-sm text-primary1">
+            {formatNumber(totalGames)}전 {formatNumber(wins)}승 {formatNumber(losses)}패
+          </div>
           <div className="text-xs text-primary2">{winRate}%</div>
         </div>
       </div>

--- a/src/pages/champion/index.tsx
+++ b/src/pages/champion/index.tsx
@@ -104,7 +104,7 @@ const Champion: NextPage = () => {
         clanName={clanName}
         title="대상 분석"
         date={getCurrentYearMonth()}
-        description="챔피언 플레이 기록이 30판 이상인 경우에만 통계에 표시"
+        description="챔피언 플레이 기록이 20판 이상인 경우에만 통계에 표시"
       />
 
       <PositionFilter
@@ -180,7 +180,7 @@ const Champion: NextPage = () => {
                   isFetchedStatistics &&
                   allChampions.length === 0 && (
                     <div className="text-center py-10 text-primary2 bg-darkBg2 rounded border border-border2">
-                      30판 이상 플레이한 챔피언이 없어 통계 데이터를 확인할 수 없습니다.
+                      20판 이상 플레이한 챔피언이 없어 통계 데이터를 확인할 수 없습니다.
                     </div>
                   )}
               </>

--- a/src/pages/champion/index.tsx
+++ b/src/pages/champion/index.tsx
@@ -102,7 +102,7 @@ const Champion: NextPage = () => {
       <TitleBox
         className="mt-10"
         clanName={clanName}
-        title="대상 분석"
+        title="챔피언 분석"
         date={getCurrentYearMonth()}
         description="챔피언 플레이 기록이 20판 이상인 경우에만 통계에 표시"
       />

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -100,7 +100,7 @@ const User: NextPage = () => {
         clanName={clanName}
         title="유저 분석"
         date={getCurrentYearMonth()}
-        description="내전 플레이 기록이 30판 이상인 경우에만 통계에 표시"
+        description="내전 플레이 기록이 20판 이상인 경우에만 통계에 표시"
       />
 
       <PositionFilter
@@ -161,7 +161,7 @@ const User: NextPage = () => {
                   isFetchedStatistics &&
                   allUsers.length === 0 && (
                     <div className="text-center py-10 text-primary2 bg-darkBg2 rounded border border-border2">
-                      30판 이상 플레이한 유저가 없어 통계 데이터를 확인할 수 없습니다.
+                      20판 이상 플레이한 유저가 없어 통계 데이터를 확인할 수 없습니다.
                     </div>
                   )}
               </>

--- a/src/services/statistics.ts
+++ b/src/services/statistics.ts
@@ -9,8 +9,12 @@ export const getUserStatistics = async (
   position: Position
 ): Promise<ApiResponse<UserStatisticsResponse>> => {
   try {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = now.getMonth() + 1;
+
     return await api.get(
-      `/api/statistics/${guildId}/users?position=${position}&sortBy=winRate&limit=100000`
+      `/api/statistics/${guildId}/users?position=${position}&sortBy=winRate&limit=100000&year=${year}&month=${month}`
     );
   } catch (error) {
     return {
@@ -26,8 +30,12 @@ export const getChampionStatistics = async (
   position: Position
 ): Promise<ApiResponse<ChampionStatisticsResponse>> => {
   try {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = now.getMonth() + 1;
+
     return await api.get(
-      `/api/statistics/${guildId}/champions?position=${position}&sortBy=winRate&limit=100000`
+      `/api/statistics/${guildId}/champions?position=${position}&sortBy=winRate&limit=100000&year=${year}&month=${month}`
     );
   } catch (error) {
     return {


### PR DESCRIPTION
## ✏️ 수정된 사항
- 통계 공통 : 
  - (버그) 현재에 해당하는 월을 쿼리에 넣어서 현재 월 데이터만 보여주기
  - 기존 '30판'을 -> '20판'으로 코멘트 수정
- 유저 분석 페이지 : 
  - 전적, 승률 데이터 정렬 기능 추가
  - KDA ↔︎ 전적 열 위치 바꾸기


## 📱 Preview
하단 예시에서는 현재 월에 해당하는 최신 데이터가 없어서 안보이는 중
<img width="1119" height="746" alt="image" src="https://github.com/user-attachments/assets/6343ea59-6bb4-49b3-b564-e248cd1c48da" />
<img width="1097" height="435" alt="image" src="https://github.com/user-attachments/assets/33f00f96-17a9-48b4-9692-da831fb9ef2d" />
