### PR TITLE
[TRC-167] 전적 페이지 버그 수정

### DIFF
--- a/src/pages/summoners/[riotName]/[riotTag].tsx
+++ b/src/pages/summoners/[riotName]/[riotTag].tsx
@@ -51,6 +51,16 @@ const RiotProfilePage = () => {
     );
   };
 
+  // 유효한 매치 데이터가 있는지 확인
+  const hasValidMatchData = (data: MatchDashboardData): boolean => {
+    return (
+      data.summary.totalCount > 0 ||
+      data.lines.length > 0 ||
+      data.mostPicks.length > 0 ||
+      data.synergy.length > 0
+    );
+  };
+
   // 타입 가드: MultiplePlayerInfo[] 배열인지 확인
   const isMultiplePlayerInfo = (data: unknown): data is MultiplePlayerInfo[] => {
     return Array.isArray(data);
@@ -100,7 +110,7 @@ const RiotProfilePage = () => {
         }
 
         // 단일 검색 결과인 경우
-        if (data && isMatchDashboardData(data)) {
+        if (data && isMatchDashboardData(data) && hasValidMatchData(data)) {
           return (
             <UserRecordPanel
               key={`${riotNameString}-${riotTagString}`}


### PR DESCRIPTION
## ✏️ 수정한 사항
경기 1건만 갖고있다가 해당 경기가 삭제되어 0건의 경기를 갖게된 경우, 전적 화면 표시 안되는 버그 수정
해당 상황에서 dashboard api 응답은 아래와 같음.
```json
{
  "status": "success",
  "message": "Match dashboard data retrieved successfully",
  "data": {
    "member": {
      "playerCode": "가리겠습니다",
      "riotName": "덜커덕",
      "riotNameTag": "커 덕",
      "isMain": true,
      "guildId": "가리겠습니다",
      "createDate": "2026-01-08T01:26:32.463Z",
      "updateDate": "2026-01-08T01:26:32.463Z",
      "isDeleted": false
    },
    "summary": {
      "totalCount": 0,
      "win": 0,
      "lose": 0,
      "winRate": "0",
      "kda": "9999"
    },
    "lines": [],
    "mostPicks": [],
    "synergy": []
  }
}
```
재현 링크 : https://dev.gmok.kr/summoners/%EB%8D%9C%EC%BB%A4%EB%8D%95/%EC%BB%A4%20%EB%8D%95

### 기존
<img width="728" height="183" alt="image" src="https://github.com/user-attachments/assets/ad51988f-b9dc-4e21-8e9f-9c844abc81a6" />

### 수정 후
<img width="1202" height="321" alt="image" src="https://github.com/user-attachments/assets/83e7bbf4-4383-4222-92f3-69c9de48d91e" />
