### PR TITLE
Feature/trc 170 v2 릴리즈 개선

### DIFF
--- a/src/components/layout/SummonerPageHeader.tsx
+++ b/src/components/layout/SummonerPageHeader.tsx
@@ -6,11 +6,14 @@ import TextLogo from "@/assets/images/textLogo.png";
 import NavBar from "@/components/layout/NavBar";
 import SearchBarSmall from "@/components/form/SearchBarSmall";
 import SearchBarResultList from "@/features/search/SearchBarResultList";
+import RecentSearchList from "@/features/search/RecentSearchList";
 import DiscordLoginButton from "@/components/ui/DiscordLoginButton";
 import GuildDropdown from "@/features/discordLogin/GuildDropdown";
 import useClickOutside from "@/hooks/common/useClickOutside";
 import { PlayerInfo } from "@/data/types/user";
 import { GuildInfo } from "@/data/types/auth";
+import { addRecentSearch } from "@/utils/recentSearches";
+import { handleRiotNameSearch } from "@/utils/parseRiotSearch";
 
 interface Props {
   searchTerm: string;
@@ -49,6 +52,26 @@ const SummonerPageHeader = ({
     window.location.href = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auth/login`;
   };
 
+  // 검색 실행 및 최근 검색어 저장
+  const handleSearch = () => {
+    const [riotName, riotTag] = handleRiotNameSearch(searchTerm);
+
+    // 최근 검색어 저장 (동기 처리)
+    if (riotName && riotTag) {
+      addRecentSearch({ riotName, riotTag });
+    }
+
+    // 페이지 이동
+    onSearch();
+  };
+
+  // 최근 검색어 클릭 핸들러
+  const handleRecentSearchClick = (riotName: string, riotTag: string) => {
+    // 최근 검색어 저장 후 페이지 이동
+    addRecentSearch({ riotName, riotTag });
+    router.push(`/summoners/${encodeURIComponent(riotName)}/${encodeURIComponent(riotTag)}`);
+  };
+
   return (
     <header className="flex flex-col md:flex-row justify-start md:justify-between mt-2 md:mt-10 md:items-center md:gap-10 md:min-w-[1080px]">
       <div className="flex flex-col md:flex-row items-center gap-4 md:min-w-[450px]">
@@ -76,17 +99,22 @@ const SummonerPageHeader = ({
           <SearchBarSmall
             value={searchTerm}
             onChange={setSearchTerm}
-            onSearch={onSearch}
+            onSearch={handleSearch}
             placeholder="플레이어 이름#KR1"
             onFocus={() => setIsSearchFocused(true)}
           />
-          <SearchBarResultList
-            isLoading={isLoading}
-            isError={isError}
-            users={users}
-            enable={isSearchFocused}
-            searchTerm={searchTerm}
-          />
+          {/* 검색 결과 또는 최근 검색어 */}
+          {searchTerm.length >= 2 ? (
+            <SearchBarResultList
+              isLoading={isLoading}
+              isError={isError}
+              users={users}
+              enable={isSearchFocused}
+              searchTerm={searchTerm}
+            />
+          ) : (
+            <RecentSearchList enable={isSearchFocused} onSearchClick={handleRecentSearchClick} />
+          )}
         </div>
       </div>
       <div className="flex items-center justify-start md:justify-end gap-3 mt-3 md:mt-0">

--- a/src/components/layout/SummonerPageHeader.tsx
+++ b/src/components/layout/SummonerPageHeader.tsx
@@ -12,8 +12,6 @@ import GuildDropdown from "@/features/discordLogin/GuildDropdown";
 import useClickOutside from "@/hooks/common/useClickOutside";
 import { PlayerInfo } from "@/data/types/user";
 import { GuildInfo } from "@/data/types/auth";
-import { addRecentSearch } from "@/utils/recentSearches";
-import { handleRiotNameSearch } from "@/utils/parseRiotSearch";
 
 interface Props {
   searchTerm: string;
@@ -52,23 +50,8 @@ const SummonerPageHeader = ({
     window.location.href = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auth/login`;
   };
 
-  // 검색 실행 및 최근 검색어 저장
-  const handleSearch = () => {
-    const [riotName, riotTag] = handleRiotNameSearch(searchTerm);
-
-    // 최근 검색어 저장 (동기 처리)
-    if (riotName && riotTag) {
-      addRecentSearch({ riotName, riotTag });
-    }
-
-    // 페이지 이동
-    onSearch();
-  };
-
   // 최근 검색어 클릭 핸들러
   const handleRecentSearchClick = (riotName: string, riotTag: string) => {
-    // 최근 검색어 저장 후 페이지 이동
-    addRecentSearch({ riotName, riotTag });
     router.push(`/summoners/${encodeURIComponent(riotName)}/${encodeURIComponent(riotTag)}`);
   };
 
@@ -99,7 +82,7 @@ const SummonerPageHeader = ({
           <SearchBarSmall
             value={searchTerm}
             onChange={setSearchTerm}
-            onSearch={handleSearch}
+            onSearch={onSearch}
             placeholder="플레이어 이름#KR1"
             onFocus={() => setIsSearchFocused(true)}
           />

--- a/src/components/layout/SummonerPageHeader.tsx
+++ b/src/components/layout/SummonerPageHeader.tsx
@@ -56,7 +56,7 @@ const SummonerPageHeader = ({
   };
 
   return (
-    <header className="flex flex-col md:flex-row justify-start md:justify-between mt-2 md:mt-10 md:items-center md:gap-10 md:min-w-[1080px]">
+    <header className="flex flex-col md:flex-row justify-start md:justify-between pt-4 md:pt-6 px-4 md:px-0 md:items-center md:gap-10 md:min-w-[1080px]">
       <div className="flex flex-col md:flex-row items-center gap-4 md:min-w-[450px]">
         <div className="md:hidden self-end flex gap-3 items-center">
           {isLoggedIn && (

--- a/src/components/ui/ItemWithTooltip.tsx
+++ b/src/components/ui/ItemWithTooltip.tsx
@@ -1,0 +1,59 @@
+import React, { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { fetchAllItems, getItemDataFromCache } from "@/utils/lolData";
+import { getItemSprite } from "@/utils/spriteLoader";
+import Tooltip from "./Tooltip";
+import SpriteImage from "./SpriteImage";
+
+interface Props {
+  itemId: number;
+  width: number;
+  height: number;
+  className?: string;
+  alt?: string;
+}
+
+const ItemWithTooltip = ({ itemId, width, height, className = "", alt = "아이템" }: Props) => {
+  const { data: allItems } = useQuery({
+    queryKey: ["lol-items"],
+    queryFn: fetchAllItems,
+    staleTime: 1000 * 60 * 60,
+    gcTime: 1000 * 60 * 60,
+    enabled: itemId !== 0,
+  });
+
+  const itemInfo = useMemo(() => getItemDataFromCache(allItems, itemId), [allItems, itemId]);
+
+  if (itemId === 0) return null;
+
+  const tooltipContent = itemInfo ? (
+    <>
+      <div className="font-bold text-yellow mb-2">{itemInfo.name}</div>
+      {itemInfo.plaintext && (
+        <div className="text-gray-300 mb-2 leading-relaxed">{itemInfo.plaintext}</div>
+      )}
+      {itemInfo.description && (
+        <div className="text-gray-400 leading-relaxed mt-2">{itemInfo.description}</div>
+      )}
+      <div className="mt-2">
+        <span className="text-gray-300">가격: </span>
+        <span className="text-yellow font-semibold">{itemInfo.gold.total}G</span>
+      </div>
+    </>
+  ) : null;
+
+  return (
+    <Tooltip content={tooltipContent}>
+      <SpriteImage
+        spriteData={getItemSprite(itemId)}
+        width={width}
+        height={height}
+        alt={alt}
+        fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/item/${itemId}.png`}
+        className={className}
+      />
+    </Tooltip>
+  );
+};
+
+export default ItemWithTooltip;

--- a/src/components/ui/RuneWithTooltip.tsx
+++ b/src/components/ui/RuneWithTooltip.tsx
@@ -1,0 +1,57 @@
+import React, { useMemo } from "react";
+import Image from "next/image";
+import { useQuery } from "@tanstack/react-query";
+import { fetchAllRunes, getRuneDataFromCache } from "@/utils/lolData";
+import Tooltip from "./Tooltip";
+
+interface Props {
+  iconPath: string;
+  runeName: string;
+  width: number;
+  height: number;
+  alt?: string;
+}
+
+const RuneWithTooltip = ({ iconPath, runeName, width, height, alt = "룬" }: Props) => {
+  const { data: allRunes } = useQuery({
+    queryKey: ["lol-runes"],
+    queryFn: fetchAllRunes,
+    staleTime: 1000 * 60 * 60,
+    gcTime: 1000 * 60 * 60,
+    enabled: !!iconPath,
+  });
+
+  const runeInfo = useMemo(() => getRuneDataFromCache(allRunes, iconPath), [allRunes, iconPath]);
+
+  if (!iconPath) return null;
+
+  const tooltipContent = runeInfo ? (
+    <>
+      <div className="font-bold text-purple-400 mb-2">{runeInfo.name}</div>
+      {runeInfo.description && (
+        <div className="text-gray-300 leading-relaxed">{runeInfo.description}</div>
+      )}
+    </>
+  ) : (
+    <div>{runeName}</div>
+  );
+
+  return (
+    <Tooltip content={tooltipContent}>
+      <div style={{ width: `${width}px`, height: `${height}px`, display: "block", lineHeight: 0 }}>
+        <Image
+          width={width}
+          height={height}
+          alt={alt}
+          src={`https://ddragon.leagueoflegends.com/cdn/img/${iconPath}`}
+          loading="lazy"
+          unoptimized
+          className="block"
+          style={{ width: "100%", height: "100%" }}
+        />
+      </div>
+    </Tooltip>
+  );
+};
+
+export default RuneWithTooltip;

--- a/src/components/ui/SpellWithTooltip.tsx
+++ b/src/components/ui/SpellWithTooltip.tsx
@@ -1,0 +1,65 @@
+import React, { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { fetchAllSpells, getSpellDataFromCache } from "@/utils/lolData";
+import { getSummonerSpellSprite } from "@/utils/spriteLoader";
+import Tooltip from "./Tooltip";
+import SpriteImage from "./SpriteImage";
+
+interface Props {
+  spellKey: string;
+  spellName: string;
+  width: number;
+  height: number;
+  className?: string;
+  alt?: string;
+}
+
+const SpellWithTooltip = ({
+  spellKey,
+  spellName,
+  width,
+  height,
+  className = "",
+  alt = "스펠",
+}: Props) => {
+  const { data: allSpells } = useQuery({
+    queryKey: ["lol-spells"],
+    queryFn: fetchAllSpells,
+    staleTime: 1000 * 60 * 60,
+    gcTime: 1000 * 60 * 60,
+    enabled: !!spellKey,
+  });
+
+  const spellInfo = useMemo(
+    () => getSpellDataFromCache(allSpells, spellKey),
+    [allSpells, spellKey]
+  );
+
+  if (!spellKey) return null;
+
+  const tooltipContent = spellInfo ? (
+    <>
+      <div className="font-bold text-cyan-400 mb-2">{spellInfo.name}</div>
+      {spellInfo.description && (
+        <div className="text-gray-300 leading-relaxed">{spellInfo.description}</div>
+      )}
+    </>
+  ) : (
+    <div>{spellName}</div>
+  );
+
+  return (
+    <Tooltip content={tooltipContent}>
+      <SpriteImage
+        spriteData={getSummonerSpellSprite(spellKey)}
+        width={width}
+        height={height}
+        alt={alt}
+        fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/spell/${spellKey}.png`}
+        className={className}
+      />
+    </Tooltip>
+  );
+};
+
+export default SpellWithTooltip;

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,0 +1,31 @@
+import React, { ReactNode, useState } from "react";
+
+interface Props {
+  content: ReactNode;
+  children: ReactNode;
+  className?: string;
+}
+
+const Tooltip = ({ content, children, className = "" }: Props) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  return (
+    <div
+      className={`relative inline-block ${className}`}
+      onMouseEnter={() => setIsVisible(true)}
+      onMouseLeave={() => setIsVisible(false)}
+    >
+      {children}
+      {isVisible && content && (
+        <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 z-50 pointer-events-none">
+          <div className="px-3 py-2 rounded bg-black text-white text-sm max-w-[320px] break-words overflow-wrap-anywhere">
+            {content}
+          </div>
+          <div className="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-black" />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Tooltip;

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -17,11 +17,11 @@ const Tooltip = ({ content, children, className = "" }: Props) => {
     >
       {children}
       {isVisible && content && (
-        <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 z-50 pointer-events-none">
-          <div className="px-3 py-2 rounded bg-black text-white text-sm max-w-[320px] break-words overflow-wrap-anywhere">
+        <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-[9999] pointer-events-none">
+          <div className="px-3 py-2 rounded bg-black text-white text-sm w-[240px] max-w-[320px] whitespace-normal break-words text-left">
             {content}
           </div>
-          <div className="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-black" />
+          <div className="absolute top-full left-1/2 -translate-x-1/2 w-0 h-0 border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-black" />
         </div>
       )}
     </div>

--- a/src/features/matchHistory/MatchDetail.tsx
+++ b/src/features/matchHistory/MatchDetail.tsx
@@ -28,8 +28,11 @@ const MatchDetail = ({ participantData }: Props) => {
         // participant.item6, // Trinket(와드 토템, 예언자의 렌즈, 파란 정찰 와드 등을 통칭)
       ],
       spells: [participant.summonerSpell1Key, participant.summonerSpell2Key],
+      spellNames: [participant.summonerSpell1Name, participant.summonerSpell2Name],
       keystone: participant.keystoneIcon,
+      keystoneName: participant.keystoneName,
       perk: participant.substyleIcon,
+      perkName: participant.substyleName,
       killParticipation: totalTeamKills
         ? Number((((participant.kill + participant.assist) / totalTeamKills) * 100).toFixed(2))
         : 0,

--- a/src/features/matchHistory/MatchDetailTable.tsx
+++ b/src/features/matchHistory/MatchDetailTable.tsx
@@ -34,12 +34,12 @@ interface MatchDetailProps {
 const MatchDetailTable = ({ players, isWin }: MatchDetailProps) => {
   return (
     <div className={`${isWin ? "bg-blueLighten" : "bg-redLighten"} rounded-md text-base`}>
-      <div className="grid grid-cols-[1.5fr_0.5fr_1.5fr_1fr_1fr_1fr_1fr] place-items-center text-center gap-y-1 py-[2px] whitespace-nowrap">
+      <div className="grid grid-cols-[0.7fr_100px_1.2fr_0.8fr_0.7fr_1fr_0.8fr] place-items-center text-center gap-y-1 py-[2px] whitespace-nowrap">
         {/* 제목 행 */}
         {isWin && (
           <>
-            <div className="bg-border1 text-white font-bold w-full">소환사명</div>
             <div className="bg-border1 text-white font-bold w-full">챔피언</div>
+            <div className="bg-border1 text-white font-bold w-full">소환사명</div>
             <div className="bg-border1 text-white font-bold w-full">빌드</div>
             <div className="bg-border1 text-white font-bold w-full">KDA</div>
             <div className="bg-border1 text-white font-bold w-full">킬관여율</div>
@@ -51,10 +51,7 @@ const MatchDetailTable = ({ players, isWin }: MatchDetailProps) => {
         {/* 데이터 행 */}
         {players.map((player) => (
           <React.Fragment key={`${player.name}-${player.tag}`}>
-            {/* 1. 챔피언 이름 */}
-            <PlayerNameButton name={player.name} tag={player.tag} />
-
-            {/* 2. 챔피언 이미지 */}
+            {/* 1. 챔피언 이미지 */}
             <div className="flex text-left w-[36px] h-[36px]">
               <SpriteImage
                 spriteData={getChampionSprite(player.champNameEng)}
@@ -65,6 +62,9 @@ const MatchDetailTable = ({ players, isWin }: MatchDetailProps) => {
                 className="w-[36px] h-[36px]"
               />
             </div>
+
+            {/* 2. 소환사명 */}
+            <PlayerNameButton name={player.name} tag={player.tag} isCenter={false} />
 
             {/* 3. 빌드(룬, 스펠, 아이템) */}
             <div className="flex gap-x-2">

--- a/src/features/matchHistory/MatchDetailTable.tsx
+++ b/src/features/matchHistory/MatchDetailTable.tsx
@@ -6,8 +6,11 @@ import EyeIcon from "@/assets/images/eye.png";
 import SwordIcon from "@/assets/images/sword.png";
 import WardIcon from "@/assets/images/ward.png";
 import SpriteImage from "@/components/ui/SpriteImage";
-import { getChampionSprite, getItemSprite, getSummonerSpellSprite } from "@/utils/spriteLoader";
+import { getChampionSprite } from "@/utils/spriteLoader";
 import { getKdaColor } from "@/utils/statColors";
+import ItemWithTooltip from "@/components/ui/ItemWithTooltip";
+import SpellWithTooltip from "@/components/ui/SpellWithTooltip";
+import RuneWithTooltip from "@/components/ui/RuneWithTooltip";
 
 interface Player {
   name: string;
@@ -21,8 +24,11 @@ interface Player {
   wards: number;
   items: number[];
   spells: string[];
+  spellNames: string[];
   keystone: string;
+  keystoneName: string;
   perk: string;
+  perkName: string;
   killParticipation: number;
 }
 
@@ -70,39 +76,37 @@ const MatchDetailTable = ({ players, isWin }: MatchDetailProps) => {
             <div className="flex gap-x-2">
               <div className="flex">
                 <div className="flex flex-col gap-0">
-                  <SpriteImage
-                    spriteData={getSummonerSpellSprite(player.spells[0])}
+                  <SpellWithTooltip
+                    spellKey={player.spells[0]}
+                    spellName={player.spellNames[0]}
                     width={18}
                     height={18}
                     alt="스펠 1"
-                    fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/spell/${player.spells[0]}.png`}
                     className="w-[18px] h-[18px]"
                   />
-                  <SpriteImage
-                    spriteData={getSummonerSpellSprite(player.spells[1])}
+                  <SpellWithTooltip
+                    spellKey={player.spells[1]}
+                    spellName={player.spellNames[1]}
                     width={18}
                     height={18}
                     alt="스펠 2"
-                    fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/spell/${player.spells[1]}.png`}
                     className="w-[18px] h-[18px]"
                   />
                 </div>
-                <div className="flex flex-col">
-                  <Image
+                <div className="flex flex-col gap-0">
+                  <RuneWithTooltip
+                    iconPath={player.keystone}
+                    runeName={player.keystoneName}
                     width={18}
                     height={18}
                     alt="룬 1"
-                    src={`https://ddragon.leagueoflegends.com/cdn/img/${player.keystone}`}
-                    loading="lazy"
-                    unoptimized
                   />
-                  <Image
+                  <RuneWithTooltip
+                    iconPath={player.perk}
+                    runeName={player.perkName}
                     width={18}
                     height={18}
                     alt="룬 2"
-                    src={`https://ddragon.leagueoflegends.com/cdn/img/${player.perk}`}
-                    loading="lazy"
-                    unoptimized
                   />
                 </div>
               </div>
@@ -110,13 +114,12 @@ const MatchDetailTable = ({ players, isWin }: MatchDetailProps) => {
                 {player.items
                   .filter((item) => item !== 0)
                   .map((item, index) => (
-                    <SpriteImage
+                    <ItemWithTooltip
                       key={item}
-                      spriteData={getItemSprite(item)}
+                      itemId={item}
                       width={18}
                       height={18}
                       alt={`아이템 ${index + 1}`}
-                      fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/item/${item}.png`}
                       className="w-[18px] h-[18px]"
                     />
                   ))}

--- a/src/features/matchHistory/MatchDetailTableMobile.tsx
+++ b/src/features/matchHistory/MatchDetailTableMobile.tsx
@@ -6,8 +6,11 @@ import EyeIcon from "@/assets/images/eye.png";
 import SwordIcon from "@/assets/images/sword.png";
 import WardIcon from "@/assets/images/ward.png";
 import SpriteImage from "@/components/ui/SpriteImage";
-import { getChampionSprite, getItemSprite, getSummonerSpellSprite } from "@/utils/spriteLoader";
+import { getChampionSprite } from "@/utils/spriteLoader";
 import { getKdaColor } from "@/utils/statColors";
+import ItemWithTooltip from "@/components/ui/ItemWithTooltip";
+import SpellWithTooltip from "@/components/ui/SpellWithTooltip";
+import RuneWithTooltip from "@/components/ui/RuneWithTooltip";
 
 interface Player {
   name: string;
@@ -21,8 +24,11 @@ interface Player {
   wards: number;
   items: number[];
   spells: string[];
+  spellNames: string[];
   keystone: string;
+  keystoneName: string;
   perk: string;
+  perkName: string;
   killParticipation: number;
 }
 
@@ -50,39 +56,37 @@ const MatchDetailTableMobile = ({ players, isWin }: MatchDetailProps) => {
               />
               <div className="flex">
                 <div className="flex flex-col gap-0">
-                  <SpriteImage
-                    spriteData={getSummonerSpellSprite(player.spells[0])}
+                  <SpellWithTooltip
+                    spellKey={player.spells[0]}
+                    spellName={player.spellNames[0]}
                     width={12}
                     height={12}
                     alt="스펠 1"
-                    fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/spell/${player.spells[0]}.png`}
                     className="w-[12px] h-[12px]"
                   />
-                  <SpriteImage
-                    spriteData={getSummonerSpellSprite(player.spells[1])}
+                  <SpellWithTooltip
+                    spellKey={player.spells[1]}
+                    spellName={player.spellNames[1]}
                     width={12}
                     height={12}
                     alt="스펠 2"
-                    fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/spell/${player.spells[1]}.png`}
                     className="w-[12px] h-[12px]"
                   />
                 </div>
-                <div className="flex flex-col">
-                  <Image
+                <div className="flex flex-col gap-0">
+                  <RuneWithTooltip
+                    iconPath={player.keystone}
+                    runeName={player.keystoneName}
                     width={12}
                     height={12}
                     alt="룬 1"
-                    src={`https://ddragon.leagueoflegends.com/cdn/img/${player.keystone}`}
-                    loading="lazy"
-                    unoptimized
                   />
-                  <Image
+                  <RuneWithTooltip
+                    iconPath={player.perk}
+                    runeName={player.perkName}
                     width={12}
                     height={12}
                     alt="룬 2"
-                    src={`https://ddragon.leagueoflegends.com/cdn/img/${player.perk}`}
-                    loading="lazy"
-                    unoptimized
                   />
                 </div>
               </div>
@@ -95,13 +99,12 @@ const MatchDetailTableMobile = ({ players, isWin }: MatchDetailProps) => {
                 {player.items
                   .filter((item) => item !== 0)
                   .map((item, index) => (
-                    <SpriteImage
+                    <ItemWithTooltip
                       key={item}
-                      spriteData={getItemSprite(item)}
+                      itemId={item}
                       width={12}
                       height={12}
                       alt={`아이템 ${index + 1}`}
-                      fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/item/${item}.png`}
                       className="w-[12px] h-[12px]"
                     />
                   ))}

--- a/src/features/matchHistory/MatchItem.tsx
+++ b/src/features/matchHistory/MatchItem.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { MdKeyboardArrowDown } from "react-icons/md";
-import Image from "next/image";
 import MatchDetail from "@/features/matchHistory/MatchDetail";
 import { GameRecordResponse, RecentGameRecord } from "@/data/types/record";
 import { useQuery } from "@tanstack/react-query";
@@ -8,9 +7,12 @@ import { ApiResponse } from "@/services/apiService";
 import { getGameRecords } from "@/services/record";
 import { formatTimeAgo } from "@/utils/parseTime";
 import SpriteImage from "@/components/ui/SpriteImage";
-import { getChampionSprite, getItemSprite, getSummonerSpellSprite } from "@/utils/spriteLoader";
+import { getChampionSprite } from "@/utils/spriteLoader";
 import LoadingSpinner from "@/components/ui/LoadingSpinner";
 import { getKdaColor } from "@/utils/statColors";
+import ItemWithTooltip from "@/components/ui/ItemWithTooltip";
+import SpellWithTooltip from "@/components/ui/SpellWithTooltip";
+import RuneWithTooltip from "@/components/ui/RuneWithTooltip";
 
 interface Props {
   matchData: RecentGameRecord;
@@ -124,24 +126,22 @@ const MatchItem = ({ matchData }: Props) => {
               {/* 스펠 - 모바일 */}
               <div className="flex flex-col gap-0 sm:hidden">
                 {matchData.summonerSpell1Key && (
-                  <SpriteImage
-                    spriteData={getSummonerSpellSprite(matchData.summonerSpell1Key)}
+                  <SpellWithTooltip
+                    spellKey={matchData.summonerSpell1Key}
+                    spellName={matchData.summonerSpell1Name}
                     width={18}
                     height={18}
                     alt="스펠 1"
-                    title={matchData.summonerSpell1Name}
-                    fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/spell/${matchData.summonerSpell1Key}.png`}
                     className="w-[18px] h-[18px]"
                   />
                 )}
                 {matchData.summonerSpell2Key && (
-                  <SpriteImage
-                    spriteData={getSummonerSpellSprite(matchData.summonerSpell2Key)}
+                  <SpellWithTooltip
+                    spellKey={matchData.summonerSpell2Key}
+                    spellName={matchData.summonerSpell2Name}
                     width={18}
                     height={18}
                     alt="스펠 2"
-                    title={matchData.summonerSpell2Name}
-                    fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/spell/${matchData.summonerSpell2Key}.png`}
                     className="w-[18px] h-[18px]"
                   />
                 )}
@@ -149,50 +149,44 @@ const MatchItem = ({ matchData }: Props) => {
               {/* 스펠 - 데스크탑 */}
               <div className="hidden sm:flex flex-col gap-0">
                 {matchData.summonerSpell1Key && (
-                  <SpriteImage
-                    spriteData={getSummonerSpellSprite(matchData.summonerSpell1Key)}
+                  <SpellWithTooltip
+                    spellKey={matchData.summonerSpell1Key}
+                    spellName={matchData.summonerSpell1Name}
                     width={32}
                     height={32}
                     alt="스펠 1"
-                    title={matchData.summonerSpell1Name}
-                    fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/spell/${matchData.summonerSpell1Key}.png`}
                     className="w-8 h-8"
                   />
                 )}
                 {matchData.summonerSpell2Key && (
-                  <SpriteImage
-                    spriteData={getSummonerSpellSprite(matchData.summonerSpell2Key)}
+                  <SpellWithTooltip
+                    spellKey={matchData.summonerSpell2Key}
+                    spellName={matchData.summonerSpell2Name}
                     width={32}
                     height={32}
                     alt="스펠 2"
-                    title={matchData.summonerSpell2Name}
-                    fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/spell/${matchData.summonerSpell2Key}.png`}
                     className="w-8 h-8"
                   />
                 )}
               </div>
               {/* 룬 */}
-              <div className="flex flex-col w-[18px] h-[36px] sm:w-[32px] sm:h-[64px]">
+              <div className="flex flex-col gap-0 w-[18px] sm:w-[32px]">
                 {matchData.keystoneIcon && (
-                  <Image
+                  <RuneWithTooltip
+                    iconPath={matchData.keystoneIcon}
+                    runeName={matchData.keystoneName}
                     width={32}
                     height={32}
                     alt="메인 룬"
-                    title={matchData.keystoneName}
-                    src={`https://ddragon.leagueoflegends.com/cdn/img/${matchData.keystoneIcon}`}
-                    loading="lazy"
-                    unoptimized
                   />
                 )}
                 {matchData.substyleIcon && (
-                  <Image
+                  <RuneWithTooltip
+                    iconPath={matchData.substyleIcon}
+                    runeName={matchData.substyleName}
                     width={32}
                     height={32}
                     alt="서브 룬"
-                    title={matchData.substyleName}
-                    src={`https://ddragon.leagueoflegends.com/cdn/img/${matchData.substyleIcon}`}
-                    loading="lazy"
-                    unoptimized
                   />
                 )}
               </div>
@@ -203,13 +197,12 @@ const MatchItem = ({ matchData }: Props) => {
             <div className="grid place-items-center grid-cols-3 grid-rows-2 gap-0.5 sm:hidden">
               {itemArr.map((item) =>
                 item.itemId !== 0 ? (
-                  <SpriteImage
+                  <ItemWithTooltip
                     key={`${matchData.gameId}_${matchData.riotName}_slot${item.slot}`}
-                    spriteData={getItemSprite(item.itemId)}
+                    itemId={item.itemId}
                     width={18}
                     height={18}
                     alt={`아이템 ${item.slot + 1}`}
-                    fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/item/${item.itemId}.png`}
                     className="w-[18px] h-[18px]"
                   />
                 ) : null
@@ -219,13 +212,12 @@ const MatchItem = ({ matchData }: Props) => {
             <div className="hidden sm:flex flex-row items-center gap-0">
               {itemArr.map((item) =>
                 item.itemId !== 0 ? (
-                  <SpriteImage
+                  <ItemWithTooltip
                     key={`${matchData.gameId}_${matchData.riotName}_slot${item.slot}`}
-                    spriteData={getItemSprite(item.itemId)}
+                    itemId={item.itemId}
                     width={32}
                     height={32}
                     alt={`아이템 ${item.slot + 1}`}
-                    fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/item/${item.itemId}.png`}
                     className="w-8 h-8"
                   />
                 ) : null

--- a/src/features/matchHistory/MostPickRank.tsx
+++ b/src/features/matchHistory/MostPickRank.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { MostPickStats } from "@/data/types/record";
 import RankItem from "./RankItem";
 
@@ -6,6 +7,9 @@ interface Props {
 }
 
 const MostPickRank = ({ mostPickData }: Props) => {
+  const [showAll, setShowAll] = useState(false);
+  const INITIAL_DISPLAY_COUNT = 5;
+
   const rankData = mostPickData.map((champRecord, index) => {
     return {
       rank: index + 1,
@@ -17,11 +21,24 @@ const MostPickRank = ({ mostPickData }: Props) => {
     };
   });
 
+  const displayedData = showAll ? rankData : rankData.slice(0, INITIAL_DISPLAY_COUNT);
+  const hasMore = rankData.length > INITIAL_DISPLAY_COUNT;
+
   return (
     <div className="flex flex-col gap-2 sm:gap-4">
-      {rankData.map((data) => (
+      {displayedData.map((data) => (
         <RankItem key={data.rank} {...data} />
       ))}
+
+      {hasMore && !showAll && (
+        <button
+          type="button"
+          onClick={() => setShowAll(true)}
+          className="w-full py-2 rounded bg-darkBg1 border border-border2 text-primary2 hover:bg-grayHover transition-colors text-sm"
+        >
+          더보기
+        </button>
+      )}
     </div>
   );
 };

--- a/src/features/matchHistory/PositionStats.tsx
+++ b/src/features/matchHistory/PositionStats.tsx
@@ -59,7 +59,7 @@ const PositionStats = ({ linesData }: Props) => {
           </div>
 
           {/* 통계 정보 */}
-          <div className="flex-shrink-0 flex items-center justify-center">
+          <div className="flex-shrink-0 flex items-center justify-between">
             <div className="flex-1">
               {/* 첫 번째 줄: n전 m승 b패 */}
               <div className="text-sm text-primary1">

--- a/src/features/matchHistory/PositionStats.tsx
+++ b/src/features/matchHistory/PositionStats.tsx
@@ -5,6 +5,7 @@ import LaneMidLogo from "@/assets/images/laneMid.png";
 import LaneSupportLogo from "@/assets/images/laneSupport.png";
 import LaneBottomLogo from "@/assets/images/laneBottom.png";
 import { LineStats } from "@/data/types/record";
+import { getKdaColor } from "@/utils/statColors";
 
 interface Props {
   linesData: LineStats[];
@@ -41,35 +42,36 @@ const PositionStats = ({ linesData }: Props) => {
   );
 
   return (
-    <div className="flex flex-col gap-2 sm:gap-4">
+    <div className="flex flex-col gap-1 sm:gap-4">
       {sortedLines.map((line) => (
         <div
           key={line.position}
-          className="bg-darkBg1 rounded border border-border2 p-3 flex items-center gap-4"
+          className="bg-darkBg1 rounded border border-border2 p-2 sm:p-3 flex items-center gap-2 sm:gap-4"
         >
           {/* 라인 아이콘 */}
-          <div className="flex-shrink-0 w-12 h-12 flex items-center justify-center">
+          <div className="shrink-0 w-8 h-8 sm:w-12 sm:h-12">
             <Image
               src={laneImageMap[line.position]}
               alt={line.position}
               width={48}
               height={48}
-              className="w-full h-full object-contain"
+              className="w-full h-full object-contain hidden sm:block"
             />
           </div>
 
           {/* 통계 정보 */}
-          <div className="flex-shrink-0 flex items-center justify-between">
-            <div className="flex-1">
-              {/* 첫 번째 줄: n전 m승 b패 */}
-              <div className="text-sm text-primary1">
+          <div className="flex-1 flex items-center justify-between">
+            <div>
+              <div className="text-xs sm:text-sm text-primary1">
                 {line.totalCount}전 {line.win}승 {line.lose}패
               </div>
-              {/* 두 번째 줄: 승률, KDA */}
-              <div className="text-xs text-primary2 mt-1">승률 {line.winRate}%</div>
+              <div className="text-xs text-primary2 mt-0.5 sm:mt-1">({line.winRate}%)</div>
+            </div>
+
+            <div className="text-right">
+              <div className={`text-xs sm:text-sm ${getKdaColor(line.kda)}`}>{line.kda} KDA</div>
             </div>
           </div>
-          <div className="text-sm text-primary1">KDA {line.kda}</div>
         </div>
       ))}
     </div>

--- a/src/features/matchHistory/PositionStats.tsx
+++ b/src/features/matchHistory/PositionStats.tsx
@@ -55,7 +55,7 @@ const PositionStats = ({ linesData }: Props) => {
               alt={line.position}
               width={48}
               height={48}
-              className="w-full h-full object-contain hidden sm:block"
+              className="w-full h-full object-contain"
             />
           </div>
 

--- a/src/features/matchHistory/PositionStats.tsx
+++ b/src/features/matchHistory/PositionStats.tsx
@@ -1,0 +1,79 @@
+import Image, { StaticImageData } from "next/image";
+import LaneTopLogo from "@/assets/images/laneTop.png";
+import LaneJungleLogo from "@/assets/images/laneJungle.png";
+import LaneMidLogo from "@/assets/images/laneMid.png";
+import LaneSupportLogo from "@/assets/images/laneSupport.png";
+import LaneBottomLogo from "@/assets/images/laneBottom.png";
+import { LineStats } from "@/data/types/record";
+
+interface Props {
+  linesData: LineStats[];
+}
+
+const laneImageMap: Record<string, StaticImageData> = {
+  MID: LaneMidLogo,
+  TOP: LaneTopLogo,
+  JUG: LaneJungleLogo,
+  ADC: LaneBottomLogo,
+  SUP: LaneSupportLogo,
+};
+
+const POSITION_ORDER: Array<"TOP" | "JUG" | "MID" | "ADC" | "SUP"> = [
+  "TOP",
+  "JUG",
+  "MID",
+  "ADC",
+  "SUP",
+];
+
+const PositionStats = ({ linesData }: Props) => {
+  // 포지션 순서대로 정렬
+  const sortedLines = POSITION_ORDER.map(
+    (position) =>
+      linesData.find((line) => line.position === position) || {
+        position,
+        totalCount: 0,
+        win: 0,
+        lose: 0,
+        winRate: "0.00",
+        kda: "0.00",
+      }
+  );
+
+  return (
+    <div className="flex flex-col gap-2 sm:gap-4">
+      {sortedLines.map((line) => (
+        <div
+          key={line.position}
+          className="bg-darkBg1 rounded border border-border2 p-3 flex items-center gap-4"
+        >
+          {/* 라인 아이콘 */}
+          <div className="flex-shrink-0 w-12 h-12 flex items-center justify-center">
+            <Image
+              src={laneImageMap[line.position]}
+              alt={line.position}
+              width={48}
+              height={48}
+              className="w-full h-full object-contain"
+            />
+          </div>
+
+          {/* 통계 정보 */}
+          <div className="flex-shrink-0 flex items-center justify-center">
+            <div className="flex-1">
+              {/* 첫 번째 줄: n전 m승 b패 */}
+              <div className="text-sm text-primary1">
+                {line.totalCount}전 {line.win}승 {line.lose}패
+              </div>
+              {/* 두 번째 줄: 승률, KDA */}
+              <div className="text-xs text-primary2 mt-1">승률 {line.winRate}%</div>
+            </div>
+          </div>
+          <div className="text-sm text-primary1">KDA {line.kda}</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default PositionStats;

--- a/src/features/matchHistory/RankItem.tsx
+++ b/src/features/matchHistory/RankItem.tsx
@@ -58,7 +58,7 @@ const RankItem: React.FC<RankItemProps> = ({
       </div>
 
       {/* 챔피언 정보 */}
-      <div className="ml-1 w-28 text-center whitespace-nowrap">{championName}</div>
+      <div className="ml-1 w-28 text-left whitespace-nowrap">{championName}</div>
 
       {/* KDA */}
       <div className={`ml-2 w-[72px] font-semibold ${getKdaColor(kda)} whitespace-nowrap`}>

--- a/src/features/matchHistory/RankItem.tsx
+++ b/src/features/matchHistory/RankItem.tsx
@@ -58,7 +58,7 @@ const RankItem: React.FC<RankItemProps> = ({
       </div>
 
       {/* 챔피언 정보 */}
-      <div className="ml-1 w-28 text-left whitespace-nowrap">{championName}</div>
+      <div className="ml-1 w-20 text-left whitespace-nowrap">{championName}</div>
 
       {/* KDA */}
       <div className={`ml-2 w-[72px] font-semibold ${getKdaColor(kda)} whitespace-nowrap`}>

--- a/src/features/matchHistory/RankItem.tsx
+++ b/src/features/matchHistory/RankItem.tsx
@@ -58,17 +58,17 @@ const RankItem: React.FC<RankItemProps> = ({
       </div>
 
       {/* 챔피언 정보 */}
-      <div className="ml-1 w-20 text-left whitespace-nowrap">{championName}</div>
+      <div className="ml-1 w-20 text-left whitespace-nowrap text-xs sm:text-sm">{championName}</div>
 
       {/* KDA */}
-      <div className={`ml-2 w-[72px] font-semibold ${getKdaColor(kda)} whitespace-nowrap`}>
+      <div className={`ml-2 w-[72px] text-xs sm:text-sm ${getKdaColor(kda)} whitespace-nowrap`}>
         {kda} KDA
       </div>
 
       {/* 승률 및 게임 수 */}
       <div className="flex flex-col ml-6 text-center whitespace-nowrap text-xs sm:text-sm">
-        <div className={`font-semibold ${getWinRateColor(winRate)}`}>{winRate}%</div>
-        <div className="text-gray">{games} 게임</div>
+        <div className={`${getWinRateColor(winRate)}`}>{winRate}%</div>
+        <div className="text-gray font-xs">{games} 게임</div>
       </div>
     </div>
   );

--- a/src/features/matchHistory/TeamworkStats.tsx
+++ b/src/features/matchHistory/TeamworkStats.tsx
@@ -1,0 +1,45 @@
+import { useRouter } from "next/router";
+import { SynergyStats } from "@/data/types/record";
+
+interface Props {
+  synergyData: SynergyStats[];
+}
+
+const TeamworkStats = ({ synergyData }: Props) => {
+  const router = useRouter();
+
+  const handleClick = (riotName: string, riotTag: string) => {
+    router.push(`/summoners/${encodeURIComponent(riotName)}/${encodeURIComponent(riotTag)}`);
+  };
+
+  return (
+    <div className="flex flex-col gap-1 sm:gap-4">
+      {synergyData.map((synergy) => (
+        <button
+          key={`${synergy.riotName}-${synergy.riotNameTag}`}
+          type="button"
+          onClick={() => handleClick(synergy.riotName, synergy.riotNameTag)}
+          className="bg-darkBg1 rounded border border-border2 p-2 sm:p-3 flex items-center gap-2 sm:gap-4 hover:bg-grayHover transition-colors text-left w-full"
+        >
+          {/* 닉네임 */}
+          <div className="flex-1 min-w-0">
+            <div className="text-xs sm:text-sm text-primary1 truncate hover:text-primary2">
+              {synergy.riotName}
+            </div>
+            <div className="text-xs text-primary2">#{synergy.riotNameTag}</div>
+          </div>
+
+          {/* 전적과 승률 */}
+          <div className="text-right">
+            <div className="text-xs sm:text-sm text-primary1">
+              {synergy.totalCount}전 {synergy.win}승 {synergy.lose}패
+            </div>
+            <div className="text-xs text-primary2 mt-0.5 sm:mt-1">승률 {synergy.winRate}%</div>
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default TeamworkStats;

--- a/src/features/matchHistory/UserStatsOverview.tsx
+++ b/src/features/matchHistory/UserStatsOverview.tsx
@@ -12,7 +12,6 @@ interface Props {
   riotName: string;
   riotTag: string;
   monthData: SummaryStats;
-  mostChampion: string;
   mostLane: string;
   totalData: { totalGameCount: number; winCount: number; loseCount: number; winRate: string };
   onRefresh?: () => Promise<void>;
@@ -30,7 +29,6 @@ const UserStatsOverview = ({
   riotName,
   riotTag,
   monthData,
-  mostChampion,
   mostLane,
   totalData,
   onRefresh,
@@ -49,14 +47,7 @@ const UserStatsOverview = ({
   };
 
   return (
-    <div
-      className="flex flex-col sm:flex-row bg-darkBg2 text-primary1 p-4 rounded border border-border2 relative bg-no-repeat bg-right-top w-full md:min-w-[1080px] mx-auto"
-      style={{
-        backgroundImage: `linear-gradient(to right, rgba(0, 0, 0, 0.9), rgba(0, 0, 0, 0) 100%), url(https://ddragon.leagueoflegends.com/cdn/img/champion/splash/${mostChampion}_0.jpg)`,
-        backgroundPosition: "top right",
-        backgroundRepeat: "no-repeat",
-      }}
-    >
+    <div className="flex flex-col sm:flex-row bg-darkBg2/70 backdrop-blur-md text-primary1 p-4 rounded border border-border2 relative w-full md:min-w-[1080px] mx-auto">
       {/* 라인 로고 */}
       <div className="w-[130px] h-[130px] sm:w-[140px] sm:h-[140px]">
         <Image

--- a/src/features/search/RecentSearchList.tsx
+++ b/src/features/search/RecentSearchList.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from "react";
+import { IoMdClose } from "react-icons/io";
+import { IoTimeOutline } from "react-icons/io5";
+import { getRecentSearches, removeRecentSearch, RecentSearch } from "@/utils/recentSearches";
+
+interface Props {
+  enable: boolean;
+  onSearchClick: (riotName: string, riotTag: string) => void;
+}
+
+const RecentSearchList = ({ enable, onSearchClick }: Props) => {
+  const [recentSearches, setRecentSearches] = useState<RecentSearch[]>([]);
+
+  useEffect(() => {
+    if (enable) {
+      const searches = getRecentSearches();
+      setRecentSearches(searches);
+    }
+  }, [enable]);
+
+  const handleDelete = (e: React.MouseEvent, riotName: string, riotTag: string) => {
+    e.preventDefault();
+    e.stopPropagation();
+    removeRecentSearch(riotName, riotTag);
+    setRecentSearches((prev) =>
+      prev.filter((s) => s.riotName !== riotName || s.riotTag !== riotTag)
+    );
+  };
+
+  if (!enable || recentSearches.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={`text-white bg-darkBg2 absolute w-full md:w-[400px] md:rounded-bl-lg md:rounded-br-lg md:shadow-2xl transition-opacity duration-150 ${
+        enable ? "opacity-100 visible" : "opacity-0 invisible"
+      }`}
+    >
+      <div className="max-h-[430px] overflow-y-auto scrollbar-thin scrollbar-thumb-border1 scrollbar-track-darkBg2">
+        <div className="px-3 py-2 text-sm font-bold flex items-center gap-1">
+          <IoTimeOutline className="w-4 h-4" />
+          최근 검색어
+        </div>
+        {recentSearches.map((search) => (
+          <button
+            type="button"
+            key={`${search.riotName}-${search.riotTag}`}
+            onClick={() => onSearchClick(search.riotName, search.riotTag)}
+            className="flex items-center gap-2 border-t border-rankBg1 px-3 py-2 hover:bg-rankBg2 focus:bg-gray-100 focus:outline-none focus:ring-0 last-of-type:md:rounded-bl-lg last-of-type:md:rounded-br-lg w-full"
+          >
+            <span className="flex flex-1 flex-col truncate text-left">
+              <span className="truncate text-sm text-white">
+                <b>{search.riotName}</b>
+                <em className="ml-1 text-gray">#{search.riotTag}</em>
+              </span>
+            </span>
+            <button
+              type="button"
+              onClick={(e) => handleDelete(e, search.riotName, search.riotTag)}
+              className="text-gray hover:text-white transition-colors"
+              aria-label="삭제"
+            >
+              <IoMdClose className="w-5 h-5" />
+            </button>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default RecentSearchList;

--- a/src/features/search/RecentSearchList.tsx
+++ b/src/features/search/RecentSearchList.tsx
@@ -1,20 +1,32 @@
 import React, { useEffect, useState } from "react";
-import { IoMdClose } from "react-icons/io";
+import { IoMdClose, IoMdStar, IoMdStarOutline } from "react-icons/io";
 import { IoTimeOutline } from "react-icons/io5";
 import { getRecentSearches, removeRecentSearch, RecentSearch } from "@/utils/recentSearches";
+import {
+  getFavoriteSearches,
+  toggleFavoriteSearch,
+  isFavoriteSearch,
+  FavoriteSearch,
+} from "@/utils/favoriteSearches";
 
 interface Props {
   enable: boolean;
   onSearchClick: (riotName: string, riotTag: string) => void;
 }
 
+type TabType = "recent" | "favorite";
+
 const RecentSearchList = ({ enable, onSearchClick }: Props) => {
+  const [activeTab, setActiveTab] = useState<TabType>("recent");
   const [recentSearches, setRecentSearches] = useState<RecentSearch[]>([]);
+  const [favoriteSearches, setFavoriteSearches] = useState<FavoriteSearch[]>([]);
 
   useEffect(() => {
     if (enable) {
       const searches = getRecentSearches();
+      const favorites = getFavoriteSearches();
       setRecentSearches(searches);
+      setFavoriteSearches(favorites);
     }
   }, [enable]);
 
@@ -27,7 +39,31 @@ const RecentSearchList = ({ enable, onSearchClick }: Props) => {
     );
   };
 
-  if (!enable || recentSearches.length === 0) {
+  const handleToggleFavorite = (
+    e: React.MouseEvent,
+    riotName: string,
+    riotTag: string,
+    fromFavoriteTab: boolean
+  ) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const isFavorite = toggleFavoriteSearch({ riotName, riotTag });
+
+    // 즐겨찾기 리스트 갱신
+    const updatedFavorites = getFavoriteSearches();
+    setFavoriteSearches(updatedFavorites);
+
+    // 만약 즐겨찾기 탭에서 제거한 경우, 최근 검색어도 갱신
+    if (!isFavorite && fromFavoriteTab) {
+      const searches = getRecentSearches();
+      setRecentSearches(searches);
+    }
+  };
+
+  const currentList = activeTab === "recent" ? recentSearches : favoriteSearches;
+
+  if (!enable || (recentSearches.length === 0 && favoriteSearches.length === 0)) {
     return null;
   }
 
@@ -37,34 +73,93 @@ const RecentSearchList = ({ enable, onSearchClick }: Props) => {
         enable ? "opacity-100 visible" : "opacity-0 invisible"
       }`}
     >
-      <div className="max-h-[430px] overflow-y-auto scrollbar-thin scrollbar-thumb-border1 scrollbar-track-darkBg2">
-        <div className="px-3 py-2 text-sm font-bold flex items-center gap-1">
+      {/* 탭 헤더 */}
+      <div className="flex border-b border-border1">
+        <button
+          type="button"
+          onClick={() => setActiveTab("recent")}
+          className={`flex-1 px-3 py-2 text-sm font-bold flex items-center justify-center gap-1 transition-colors ${
+            activeTab === "recent"
+              ? "text-white bg-rankBg2"
+              : "text-gray hover:text-white hover:bg-rankBg3"
+          }`}
+        >
           <IoTimeOutline className="w-4 h-4" />
           최근 검색어
-        </div>
-        {recentSearches.map((search) => (
-          <button
-            type="button"
-            key={`${search.riotName}-${search.riotTag}`}
-            onClick={() => onSearchClick(search.riotName, search.riotTag)}
-            className="flex items-center gap-2 border-t border-rankBg1 px-3 py-2 hover:bg-rankBg2 focus:bg-gray-100 focus:outline-none focus:ring-0 last-of-type:md:rounded-bl-lg last-of-type:md:rounded-br-lg w-full"
-          >
-            <span className="flex flex-1 flex-col truncate text-left">
-              <span className="truncate text-sm text-white">
-                <b>{search.riotName}</b>
-                <em className="ml-1 text-gray">#{search.riotTag}</em>
-              </span>
-            </span>
-            <button
-              type="button"
-              onClick={(e) => handleDelete(e, search.riotName, search.riotTag)}
-              className="text-gray hover:text-white transition-colors"
-              aria-label="삭제"
-            >
-              <IoMdClose className="w-5 h-5" />
-            </button>
-          </button>
-        ))}
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab("favorite")}
+          className={`flex-1 px-3 py-2 text-sm font-bold flex items-center justify-center gap-1 transition-colors ${
+            activeTab === "favorite"
+              ? "text-white bg-rankBg2"
+              : "text-gray hover:text-white hover:bg-rankBg3"
+          }`}
+        >
+          <IoMdStar className="w-4 h-4" />
+          즐겨찾기
+        </button>
+      </div>
+
+      {/* 리스트 */}
+      <div className="max-h-[430px] overflow-y-auto scrollbar-thin scrollbar-thumb-border1 scrollbar-track-darkBg2">
+        {currentList.length === 0 ? (
+          <div className="px-3 py-8 text-center text-gray text-sm">
+            {activeTab === "recent" ? "최근 검색 기록이 없습니다" : "즐겨찾기가 없습니다"}
+          </div>
+        ) : (
+          currentList.map((search) => {
+            const isFav = isFavoriteSearch(search.riotName, search.riotTag);
+            return (
+              <button
+                type="button"
+                key={`${search.riotName}-${search.riotTag}`}
+                onClick={() => onSearchClick(search.riotName, search.riotTag)}
+                className="flex items-center gap-2 border-t border-rankBg1 px-3 py-2 hover:bg-rankBg2 focus:bg-gray-100 focus:outline-none focus:ring-0 last-of-type:md:rounded-bl-lg last-of-type:md:rounded-br-lg w-full"
+              >
+                <span className="flex flex-1 flex-col truncate text-left">
+                  <span className="truncate text-sm text-white">
+                    <b>{search.riotName}</b>
+                    <em className="ml-1 text-gray">#{search.riotTag}</em>
+                  </span>
+                </span>
+
+                {/* 즐겨찾기 버튼 */}
+                <button
+                  type="button"
+                  onClick={(e) =>
+                    handleToggleFavorite(
+                      e,
+                      search.riotName,
+                      search.riotTag,
+                      activeTab === "favorite"
+                    )
+                  }
+                  className="text-gray hover:text-yellow-400 transition-colors"
+                  aria-label={isFav ? "즐겨찾기 해제" : "즐겨찾기 추가"}
+                >
+                  {isFav ? (
+                    <IoMdStar className="w-5 h-5 text-yellow-400" />
+                  ) : (
+                    <IoMdStarOutline className="w-5 h-5" />
+                  )}
+                </button>
+
+                {/* 삭제 버튼 (최근 검색어 탭에서만) */}
+                {activeTab === "recent" && (
+                  <button
+                    type="button"
+                    onClick={(e) => handleDelete(e, search.riotName, search.riotTag)}
+                    className="text-gray hover:text-white transition-colors"
+                    aria-label="삭제"
+                  >
+                    <IoMdClose className="w-5 h-5" />
+                  </button>
+                )}
+              </button>
+            );
+          })
+        )}
       </div>
     </div>
   );

--- a/src/features/search/SearchBarResultList.tsx
+++ b/src/features/search/SearchBarResultList.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { useRouter } from "next/router";
 import { PlayerInfo } from "@/data/types/user";
+import { addRecentSearch } from "@/utils/recentSearches";
 
 interface Props {
   users: PlayerInfo[] | undefined;
@@ -10,6 +12,12 @@ interface Props {
 }
 
 const SearchBarResultList = ({ users, isLoading, isError, enable, searchTerm }: Props) => {
+  const router = useRouter();
+
+  const handleUserClick = (riotName: string, riotTag: string) => {
+    addRecentSearch({ riotName, riotTag });
+    router.push(`/summoners/${encodeURIComponent(riotName)}/${encodeURIComponent(riotTag)}`);
+  };
   if (isLoading || isError || !users || !Array.isArray(users) || searchTerm.length < 2) {
     return null;
   }
@@ -23,10 +31,11 @@ const SearchBarResultList = ({ users, isLoading, isError, enable, searchTerm }: 
       <div className="max-h-[430px] overflow-y-auto scrollbar-thin scrollbar-thumb-border1 scrollbar-track-darkBg2">
         <div className="px-3 py-2 text-sm font-bold">소환사 리스트</div>
         {users.map((user) => (
-          <a
+          <button
+            type="button"
             key={user.playerCode}
-            href={`/summoners/${encodeURIComponent(user.riotName)}/${encodeURIComponent(user.riotNameTag)}`}
-            className="flex items-center gap-2 border-t border-rankBg1 px-3 py-2 hover:bg-rankBg2 focus:bg-gray-100 focus:outline-none focus:ring-0 last-of-type:md:rounded-bl-lg last-of-type:md:rounded-br-lg"
+            onClick={() => handleUserClick(user.riotName, user.riotNameTag)}
+            className="flex items-center gap-2 border-t border-rankBg1 px-3 py-2 hover:bg-rankBg2 focus:bg-gray-100 focus:outline-none focus:ring-0 last-of-type:md:rounded-bl-lg last-of-type:md:rounded-br-lg w-full text-left"
           >
             <span className="flex flex-1 flex-col truncate">
               <span className="truncate text-sm text-white">
@@ -34,7 +43,7 @@ const SearchBarResultList = ({ users, isLoading, isError, enable, searchTerm }: 
                 <em className="ml-1 text-gray">#{user.riotNameTag}</em>
               </span>
             </span>
-          </a>
+          </button>
         ))}
       </div>
     </div>

--- a/src/features/search/SearchBarResultList.tsx
+++ b/src/features/search/SearchBarResultList.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useRouter } from "next/router";
 import { PlayerInfo } from "@/data/types/user";
-import { addRecentSearch } from "@/utils/recentSearches";
 
 interface Props {
   users: PlayerInfo[] | undefined;
@@ -15,7 +14,6 @@ const SearchBarResultList = ({ users, isLoading, isError, enable, searchTerm }: 
   const router = useRouter();
 
   const handleUserClick = (riotName: string, riotTag: string) => {
-    addRecentSearch({ riotName, riotTag });
     router.push(`/summoners/${encodeURIComponent(riotName)}/${encodeURIComponent(riotTag)}`);
   };
   if (isLoading || isError || !users || !Array.isArray(users) || searchTerm.length < 2) {

--- a/src/features/statistics/UserRankItem.tsx
+++ b/src/features/statistics/UserRankItem.tsx
@@ -8,7 +8,7 @@ import LaneBottomLogo from "@/assets/images/laneBottom.png";
 
 interface Props {
   rank: number;
-  position: "TOP" | "JUG" | "MID" | "ADC" | "SUP";
+  position?: "TOP" | "JUG" | "MID" | "ADC" | "SUP";
   riotName: string;
   riotNameTag: string;
   totalGames: number;
@@ -55,15 +55,17 @@ const UserRankItem = ({
         </div>
 
         {/* 라인 아이콘 */}
-        <div className="flex-shrink-0 w-12 h-12 flex items-center justify-center">
-          <Image
-            src={laneImageMap[position] || LaneMidLogo}
-            alt={position}
-            width={48}
-            height={48}
-            className="w-full h-full object-contain"
-          />
-        </div>
+        {position && (
+          <div className="flex-shrink-0 w-12 h-12 flex items-center justify-center">
+            <Image
+              src={laneImageMap[position] || LaneMidLogo}
+              alt={position}
+              width={48}
+              height={48}
+              className="w-full h-full object-contain"
+            />
+          </div>
+        )}
 
         {/* 닉네임 */}
         <div className="flex-1 min-w-0 relative group">
@@ -111,15 +113,17 @@ const UserRankItem = ({
         </div>
 
         {/* 라인 아이콘 */}
-        <div className="flex-shrink-0 w-8 h-8 flex items-center justify-center">
-          <Image
-            src={laneImageMap[position] || LaneMidLogo}
-            alt={position}
-            width={32}
-            height={32}
-            className="w-full h-full object-contain"
-          />
-        </div>
+        {position && (
+          <div className="flex-shrink-0 w-8 h-8 flex items-center justify-center">
+            <Image
+              src={laneImageMap[position] || LaneMidLogo}
+              alt={position}
+              width={32}
+              height={32}
+              className="w-full h-full object-contain"
+            />
+          </div>
+        )}
 
         {/* 닉네임 + KDA */}
         <div className="flex-1 min-w-0">

--- a/src/features/summonerRecord/UserRecordPanel.tsx
+++ b/src/features/summonerRecord/UserRecordPanel.tsx
@@ -68,14 +68,13 @@ const UserRecordPanel = ({ riotName, riotTag, data, onRefreshRecords }: Props) =
   };
 
   return (
-    <main className="mt-10 md:mt-12 flex flex-col gap-3 md:min-w-[1080px]">
+    <main className="mt-6 md:mt-8 px-4 md:px-0 flex flex-col gap-3 md:min-w-[1080px]">
       {/* Summary */}
       <UserStatsOverview
         riotName={data.member.riotName}
         riotTag={data.member.riotNameTag}
         totalData={totalStatData}
         monthData={data.summary}
-        mostChampion={data.mostPicks[0]?.champNameEng || ""}
         mostLane={mostLane}
         onRefresh={handleRefresh}
       />

--- a/src/features/summonerRecord/UserRecordPanel.tsx
+++ b/src/features/summonerRecord/UserRecordPanel.tsx
@@ -84,19 +84,19 @@ const UserRecordPanel = ({ riotName, riotTag, data, onRefreshRecords }: Props) =
         <div className="flex flex-col gap-3">
           {/* 모스트 픽 */}
           {data.mostPicks && data.mostPicks.length > 0 && (
-            <CardWithTitle title="Most Pick" className="md:w-[350px] w-full self-start">
+            <CardWithTitle title="모스트 픽" className="md:w-[350px] w-full self-start">
               <MostPickRank mostPickData={data.mostPicks.slice(0, MOST_PICK_DISTPLAY_COUNT)} />
             </CardWithTitle>
           )}
 
           {/* 포지션 전적 */}
-          <CardWithTitle title="Position Record">
+          <CardWithTitle title="포지션 승률">
             <PositionStats linesData={data.lines} />
           </CardWithTitle>
 
           {/* 팀워크 */}
           {data.synergy && data.synergy.length > 0 && (
-            <CardWithTitle title="Teamwork">
+            <CardWithTitle title="팀워크">
               <TeamworkStats synergyData={data.synergy} />
             </CardWithTitle>
           )}
@@ -104,7 +104,7 @@ const UserRecordPanel = ({ riotName, riotTag, data, onRefreshRecords }: Props) =
 
         {/* 최근 전적 */}
         {displayedRecords && displayedRecords.length > 0 && (
-          <CardWithTitle title="Recent Matches" className="w-full">
+          <CardWithTitle title="최근 전적" className="w-full">
             <div className="flex flex-1 flex-col gap-4">
               {displayedRecords.map((datum: RecentGameRecord) => (
                 <MatchItem matchData={datum} key={datum.gameId} />

--- a/src/features/summonerRecord/UserRecordPanel.tsx
+++ b/src/features/summonerRecord/UserRecordPanel.tsx
@@ -80,7 +80,7 @@ const UserRecordPanel = ({ riotName, riotTag, data, onRefreshRecords }: Props) =
         onRefresh={handleRefresh}
       />
       <div className="flex gap-3 flex-col md:flex-row">
-        <div className="flex flex-col">
+        <div className="flex flex-col gap-3">
           {/* 모스트 픽 */}
           {data.mostPicks && data.mostPicks.length > 0 && (
             <CardWithTitle title="Most Pick" className="md:w-[350px] w-full self-start">

--- a/src/features/summonerRecord/UserRecordPanel.tsx
+++ b/src/features/summonerRecord/UserRecordPanel.tsx
@@ -11,6 +11,7 @@ import React, { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { ApiResponse } from "@/services/apiService";
 import { getRecentRecords } from "@/services/record";
+import PositionStats from "@/features/matchHistory/PositionStats";
 
 interface Props {
   riotName: string;
@@ -79,12 +80,19 @@ const UserRecordPanel = ({ riotName, riotTag, data, onRefreshRecords }: Props) =
         onRefresh={handleRefresh}
       />
       <div className="flex gap-3 flex-col md:flex-row">
-        {/* 모스트 픽 */}
-        {data.mostPicks && data.mostPicks.length > 0 && (
-          <CardWithTitle title="Most Pick" className="md:w-[350px] w-full self-start">
-            <MostPickRank mostPickData={data.mostPicks.slice(0, MOST_PICK_DISTPLAY_COUNT)} />
+        <div className="flex flex-col">
+          {/* 모스트 픽 */}
+          {data.mostPicks && data.mostPicks.length > 0 && (
+            <CardWithTitle title="Most Pick" className="md:w-[350px] w-full self-start">
+              <MostPickRank mostPickData={data.mostPicks.slice(0, MOST_PICK_DISTPLAY_COUNT)} />
+            </CardWithTitle>
+          )}
+
+          {/* 포지션 전적 */}
+          <CardWithTitle title="Position Record">
+            <PositionStats linesData={data.lines} />
           </CardWithTitle>
-        )}
+        </div>
 
         {/* 최근 전적 */}
         {displayedRecords && displayedRecords.length > 0 && (

--- a/src/features/summonerRecord/UserRecordPanel.tsx
+++ b/src/features/summonerRecord/UserRecordPanel.tsx
@@ -12,6 +12,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ApiResponse } from "@/services/apiService";
 import { getRecentRecords } from "@/services/record";
 import PositionStats from "@/features/matchHistory/PositionStats";
+import TeamworkStats from "@/features/matchHistory/TeamworkStats";
 
 interface Props {
   riotName: string;
@@ -92,6 +93,13 @@ const UserRecordPanel = ({ riotName, riotTag, data, onRefreshRecords }: Props) =
           <CardWithTitle title="Position Record">
             <PositionStats linesData={data.lines} />
           </CardWithTitle>
+
+          {/* 팀워크 */}
+          {data.synergy && data.synergy.length > 0 && (
+            <CardWithTitle title="Teamwork">
+              <TeamworkStats synergyData={data.synergy} />
+            </CardWithTitle>
+          )}
         </div>
 
         {/* 최근 전적 */}

--- a/src/features/summonerRecord/UserRecordPanel.tsx
+++ b/src/features/summonerRecord/UserRecordPanel.tsx
@@ -97,7 +97,7 @@ const UserRecordPanel = ({ riotName, riotTag, data, onRefreshRecords }: Props) =
           {/* 팀워크 */}
           {data.synergy && data.synergy.length > 0 && (
             <CardWithTitle title="팀워크">
-              <TeamworkStats synergyData={data.synergy} />
+              <TeamworkStats synergyData={data.synergy.slice(0, RECORD_DISPLAY_COUNT)} />
             </CardWithTitle>
           )}
         </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,8 +13,6 @@ import useModal from "@/hooks/common/useModal";
 import useClickOutside from "@/hooks/common/useClickOutside";
 import useUserSearchController from "@/hooks/searchUserList/useUserSearchController";
 import useGuildManagement from "@/hooks/auth/useGuildManagement";
-import { addRecentSearch } from "@/utils/recentSearches";
-import { handleRiotNameSearch } from "@/utils/parseRiotSearch";
 import MainLogo from "@/assets/images/mainLogo.png";
 
 const Home: NextPage = () => {
@@ -35,32 +33,13 @@ const Home: NextPage = () => {
     guildId
   );
 
-  // 검색 실행 및 최근 검색어 저장
+  // 검색 실행 (페이지 이동 후 해당 페이지 useEffect에서 최근 검색어 저장)
   const handleSearch = () => {
-    alert(`handleSearch 호출됨! searchTerm: ${searchTerm}`);
-    const [riotName, riotTag] = handleRiotNameSearch(searchTerm);
-    alert(`파싱 결과 - riotName: ${riotName}, riotTag: ${riotTag}`);
-
-    // 최근 검색어 저장 (동기 처리)
-    if (riotName && riotTag) {
-      alert("최근 검색어 저장 시도!");
-      addRecentSearch({ riotName, riotTag });
-      alert("addRecentSearch 호출 완료");
-
-      // 저장 확인
-      const saved = localStorage.getItem("recentSearches");
-      alert(`localStorage 확인: ${saved}`);
-    } else {
-      alert("riotName 또는 riotTag가 없음");
-    }
-
-    // 페이지 이동
     handleSearchButtonClick();
   };
 
   // 최근 검색어 클릭 핸들러
   const handleRecentSearchClick = (riotName: string, riotTag: string) => {
-    addRecentSearch({ riotName, riotTag });
     router.push(`/summoners/${encodeURIComponent(riotName)}/${encodeURIComponent(riotTag)}`);
   };
 

--- a/src/pages/summoners/[riotName]/[riotTag].tsx
+++ b/src/pages/summoners/[riotName]/[riotTag].tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import useUserSearchController from "@/hooks/searchUserList/useUserSearchController";
 import { useQuery } from "@tanstack/react-query";
 import { ApiResponse } from "@/services/apiService";
@@ -12,6 +12,7 @@ import SummonerPageHeader from "@/components/layout/SummonerPageHeader";
 import LoadingSpinner from "@/components/ui/LoadingSpinner";
 import useGuildManagement from "@/hooks/auth/useGuildManagement";
 import TextCard from "@/components/ui/TextCard";
+import { addRecentSearch } from "@/utils/recentSearches";
 
 const RiotProfilePage = () => {
   const router = useRouter();
@@ -19,6 +20,13 @@ const RiotProfilePage = () => {
   const riotNameString = Array.isArray(riotName) ? riotName[0] : riotName || "";
   const riotTagString = Array.isArray(riotTag) ? riotTag[0] : riotTag || "";
   const [searchTerm, setSearchTerm] = useState("");
+
+  // 페이지 로드 시 최근 검색어에 저장
+  useEffect(() => {
+    if (riotNameString && riotTagString) {
+      addRecentSearch({ riotName: riotNameString, riotTag: riotTagString });
+    }
+  }, [riotNameString, riotTagString]);
 
   const { guildId, guilds, isLoggedIn, username, handleGuildChange } = useGuildManagement();
 

--- a/src/pages/summoners/[riotName]/[riotTag].tsx
+++ b/src/pages/summoners/[riotName]/[riotTag].tsx
@@ -87,7 +87,7 @@ const RiotProfilePage = () => {
       style={
         mostChampion
           ? {
-              background: `linear-gradient(rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0.75)), url(https://ddragon.leagueoflegends.com/cdn/img/champion/splash/${mostChampion}_0.jpg) center/cover`,
+              background: `linear-gradient(rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0.75)), url(https://ddragon.leagueoflegends.com/cdn/img/champion/splash/${mostChampion}_0.jpg) center/cover fixed`,
               backgroundColor: "#191b20",
             }
           : {

--- a/src/pages/summoners/[riotName]/[riotTag].tsx
+++ b/src/pages/summoners/[riotName]/[riotTag].tsx
@@ -74,64 +74,83 @@ const RiotProfilePage = () => {
     return Array.isArray(data);
   };
 
+  // 배경 이미지용 mostChampion 가져오기
+  const data = userRecordData?.data?.data;
+  const mostChampion =
+    data && isMatchDashboardData(data) && data.mostPicks && data.mostPicks.length > 0
+      ? data.mostPicks[0].champNameEng
+      : "";
+
   return (
-    <div className="w-full md:max-w-[1080px] mx-auto">
-      <SummonerPageHeader
-        searchTerm={searchTerm}
-        setSearchTerm={setSearchTerm}
-        onSearch={handleSearchButtonClick}
-        isLoading={isLoading}
-        isError={isError}
-        users={userSearchData?.data}
-        guilds={guilds}
-        selectedGuildId={guildId}
-        onGuildChange={handleGuildChange}
-        username={username}
-        isLoggedIn={isLoggedIn}
-      />
+    <div
+      className="w-full min-h-screen pb-10"
+      style={
+        mostChampion
+          ? {
+              background: `linear-gradient(rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0.75)), url(https://ddragon.leagueoflegends.com/cdn/img/champion/splash/${mostChampion}_0.jpg) center/cover`,
+              backgroundColor: "#191b20",
+            }
+          : {
+              backgroundColor: "#191b20",
+            }
+      }
+    >
+      <div className="w-full md:max-w-[1080px] mx-auto">
+        <SummonerPageHeader
+          searchTerm={searchTerm}
+          setSearchTerm={setSearchTerm}
+          onSearch={handleSearchButtonClick}
+          isLoading={isLoading}
+          isError={isError}
+          users={userSearchData?.data}
+          guilds={guilds}
+          selectedGuildId={guildId}
+          onGuildChange={handleGuildChange}
+          username={username}
+          isLoggedIn={isLoggedIn}
+        />
 
-      {/* 메인 콘텐츠 */}
-      {(() => {
-        // 비로그인 상태
-        if (!isLoggedIn) {
-          return <TextCard text="로그인 후 이용해주세요" />;
-        }
+        {/* 메인 콘텐츠 */}
+        {(() => {
+          // 비로그인 상태
+          if (!isLoggedIn) {
+            return <TextCard text="로그인 후 이용해주세요" />;
+          }
 
-        // 소속 클랜 없음
-        if (guilds.length === 0) {
-          return <TextCard text="소속된 클랜이 없습니다" />;
-        }
+          // 소속 클랜 없음
+          if (guilds.length === 0) {
+            return <TextCard text="소속된 클랜이 없습니다" />;
+          }
 
-        if (!riotName || !guildId || isLoadingUserRecord) {
-          return (
-            <main>
-              <LoadingSpinner />
-            </main>
-          );
-        }
+          if (!riotName || !guildId || isLoadingUserRecord) {
+            return (
+              <main>
+                <LoadingSpinner />
+              </main>
+            );
+          }
 
-        const data = userRecordData?.data?.data;
+          // 다중 검색 결과인 경우
+          if (data && isMultiplePlayerInfo(data)) {
+            return <MultiplePlayersCard riotName={riotNameString} players={data} />;
+          }
 
-        // 다중 검색 결과인 경우
-        if (data && isMultiplePlayerInfo(data)) {
-          return <MultiplePlayersCard riotName={riotNameString} players={data} />;
-        }
+          // 단일 검색 결과인 경우
+          if (data && isMatchDashboardData(data) && hasValidMatchData(data)) {
+            return (
+              <UserRecordPanel
+                key={`${riotNameString}-${riotTagString}`}
+                riotName={riotNameString}
+                riotTag={riotTagString}
+                data={data}
+                onRefreshRecords={refetchUserRecords}
+              />
+            );
+          }
 
-        // 단일 검색 결과인 경우
-        if (data && isMatchDashboardData(data) && hasValidMatchData(data)) {
-          return (
-            <UserRecordPanel
-              key={`${riotNameString}-${riotTagString}`}
-              riotName={riotNameString}
-              riotTag={riotTagString}
-              data={data}
-              onRefreshRecords={refetchUserRecords}
-            />
-          );
-        }
-
-        return <EmptySearchResultCard riotName={riotNameString} riotTag={riotTagString} />;
-      })()}
+          return <EmptySearchResultCard riotName={riotNameString} riotTag={riotTagString} />;
+        })()}
+      </div>
     </div>
   );
 };

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -183,7 +183,7 @@ const User: NextPage = () => {
                         <UserRankItem
                           key={user.playerCode}
                           rank={index + 1}
-                          position={user.position}
+                          position={selectedPosition === "ALL" ? undefined : user.position}
                           riotName={user.riotName}
                           riotNameTag={user.riotNameTag}
                           totalGames={user.totalCount}

--- a/src/services/statistics.ts
+++ b/src/services/statistics.ts
@@ -13,8 +13,10 @@ export const getUserStatistics = async (
     const year = now.getFullYear();
     const month = now.getMonth() + 1;
 
+    const positionParam = position === "ALL" ? "" : `position=${position}&`;
+
     return await api.get(
-      `/api/statistics/${guildId}/users?position=${position}&sortBy=winRate&limit=100000&year=${year}&month=${month}`
+      `/api/statistics/${guildId}/users?${positionParam}sortBy=winRate&limit=100000&year=${year}&month=${month}`
     );
   } catch (error) {
     return {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,7 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+html,
 body {
+  margin: 0;
+  padding: 0;
   font-family: "KoPubWorld Dotum", sans-serif;
   background: #191b20;
 }

--- a/src/utils/favoriteSearches.ts
+++ b/src/utils/favoriteSearches.ts
@@ -1,0 +1,110 @@
+export interface FavoriteSearch {
+  riotName: string;
+  riotTag: string;
+}
+
+const STORAGE_KEY = "favoriteSearches";
+
+/**
+ * 즐겨찾기 목록 불러오기
+ */
+export const getFavoriteSearches = (): FavoriteSearch[] => {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return [];
+    }
+
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.error("Failed to load favorite searches:", error);
+    return [];
+  }
+};
+
+/**
+ * 즐겨찾기에 추가
+ */
+export const addFavoriteSearch = (search: FavoriteSearch): void => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (!search.riotName || !search.riotTag) {
+    return;
+  }
+
+  try {
+    const favoriteSearches = getFavoriteSearches();
+
+    // 이미 즐겨찾기에 있는지 확인
+    const exists = favoriteSearches.some(
+      (item) => item.riotName === search.riotName && item.riotTag === search.riotTag
+    );
+
+    if (exists) {
+      return;
+    }
+
+    // 맨 앞에 추가
+    const updated = [search, ...favoriteSearches];
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  } catch (error) {
+    console.error("Failed to add favorite search:", error);
+  }
+};
+
+/**
+ * 즐겨찾기에서 제거
+ */
+export const removeFavoriteSearch = (riotName: string, riotTag: string): void => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    const favoriteSearches = getFavoriteSearches();
+    const filtered = favoriteSearches.filter(
+      (item) => !(item.riotName === riotName && item.riotTag === riotTag)
+    );
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
+  } catch (error) {
+    console.error("Failed to remove favorite search:", error);
+  }
+};
+
+/**
+ * 즐겨찾기 여부 확인
+ */
+export const isFavoriteSearch = (riotName: string, riotTag: string): boolean => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    const favoriteSearches = getFavoriteSearches();
+    return favoriteSearches.some((item) => item.riotName === riotName && item.riotTag === riotTag);
+  } catch (error) {
+    console.error("Failed to check favorite search:", error);
+    return false;
+  }
+};
+
+/**
+ * 즐겨찾기 토글 (있으면 제거, 없으면 추가)
+ */
+export const toggleFavoriteSearch = (search: FavoriteSearch): boolean => {
+  if (isFavoriteSearch(search.riotName, search.riotTag)) {
+    removeFavoriteSearch(search.riotName, search.riotTag);
+    return false;
+  }
+  addFavoriteSearch(search);
+  return true;
+};

--- a/src/utils/lolData.ts
+++ b/src/utils/lolData.ts
@@ -1,0 +1,133 @@
+// Data Dragon API에서 LOL 아이템, 스펠, 룬 데이터를 가져오는 유틸리티
+
+const DDRAGON_VERSION = process.env.NEXT_PUBLIC_DDRAGON_VERSION || "14.24.1";
+const DDRAGON_BASE_URL = "https://ddragon.leagueoflegends.com/cdn";
+
+interface ItemData {
+  name: string;
+  description: string;
+  plaintext: string;
+  gold: {
+    total: number;
+  };
+}
+
+interface SummonerSpellData {
+  name: string;
+  description: string;
+}
+
+interface RuneData {
+  id: number;
+  key: string;
+  icon: string;
+  name: string;
+  slots: Array<{
+    runes: Array<{
+      id: number;
+      key: string;
+      icon: string;
+      name: string;
+      shortDesc: string;
+      longDesc: string;
+    }>;
+  }>;
+}
+
+// HTML 태그 제거
+const stripHtml = (html: string): string => {
+  return html.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ");
+};
+
+// 전체 아이템 데이터 가져오기 (React Query용)
+export const fetchAllItems = async (): Promise<Record<string, ItemData>> => {
+  const response = await fetch(`${DDRAGON_BASE_URL}/${DDRAGON_VERSION}/data/ko_KR/item.json`);
+  const json = await response.json();
+  return json.data;
+};
+
+// 특정 아이템 데이터 추출
+export const getItemDataFromCache = (
+  allItems: Record<string, ItemData> | undefined,
+  itemId: number
+): ItemData | null => {
+  if (itemId === 0 || !allItems) return null;
+
+  const itemData = allItems[itemId.toString()];
+  if (!itemData) return null;
+
+  return {
+    name: itemData.name,
+    description: stripHtml(itemData.description),
+    plaintext: itemData.plaintext || "",
+    gold: itemData.gold,
+  };
+};
+
+// 전체 소환사 주문 데이터 가져오기 (React Query용)
+export const fetchAllSpells = async (): Promise<Record<string, SummonerSpellData>> => {
+  const response = await fetch(`${DDRAGON_BASE_URL}/${DDRAGON_VERSION}/data/ko_KR/summoner.json`);
+  const json = await response.json();
+  return json.data;
+};
+
+// 특정 소환사 주문 데이터 추출
+export const getSpellDataFromCache = (
+  allSpells: Record<string, SummonerSpellData> | undefined,
+  spellKey: string
+): SummonerSpellData | null => {
+  if (!spellKey || !allSpells) return null;
+
+  const spellData = allSpells[spellKey];
+  if (!spellData) return null;
+
+  return {
+    name: spellData.name,
+    description: stripHtml(spellData.description),
+  };
+};
+
+// 전체 룬 데이터 가져오기 (React Query용)
+export const fetchAllRunes = async (): Promise<RuneData[]> => {
+  const response = await fetch(
+    `${DDRAGON_BASE_URL}/${DDRAGON_VERSION}/data/ko_KR/runesReforged.json`
+  );
+  return response.json();
+};
+
+// 특정 룬 데이터 추출 (icon path로 검색)
+export const getRuneDataFromCache = (
+  allRunes: RuneData[] | undefined,
+  iconPath: string
+): { name: string; description: string } | null => {
+  if (!iconPath || !allRunes) return null;
+
+  // icon path에서 파일명 추출 (예: "perk-images/Styles/Domination/Electrocute/Electrocute.png" -> "Electrocute")
+  const pathParts = iconPath.split("/");
+  const fileName = pathParts[pathParts.length - 1]?.replace(".png", "");
+
+  // 모든 룬 스타일과 룬을 순회하며 검색
+  // 먼저 메인 스타일 자체 확인
+  const matchingStyle = allRunes.find((style) => style.icon.includes(fileName));
+  if (matchingStyle) {
+    return {
+      name: matchingStyle.name,
+      description: "",
+    };
+  }
+
+  // 각 슬롯의 룬들 확인
+  const foundRune = allRunes
+    .flatMap((style) => style.slots)
+    .flatMap((slot) => slot.runes)
+    .find((rune) => rune.icon.includes(fileName));
+
+  if (foundRune) {
+    return {
+      name: foundRune.name,
+      description: stripHtml(foundRune.shortDesc || foundRune.longDesc),
+    };
+  }
+
+  return null;
+};

--- a/src/utils/recentSearches.ts
+++ b/src/utils/recentSearches.ts
@@ -1,0 +1,96 @@
+export interface RecentSearch {
+  riotName: string;
+  riotTag: string;
+}
+
+const STORAGE_KEY = "recentSearches";
+const MAX_RECENT_SEARCHES = 10;
+
+/**
+ * 최근 검색어 목록 불러오기
+ */
+export const getRecentSearches = (): RecentSearch[] => {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return [];
+    }
+
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.error("Failed to load recent searches:", error);
+    return [];
+  }
+};
+
+/**
+ * 최근 검색어를 추가 (중복 제거 및 최신순 정렬)
+ */
+export const addRecentSearch = (search: RecentSearch): void => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (!search.riotName || !search.riotTag) {
+    return;
+  }
+
+  try {
+    const recentSearches = getRecentSearches();
+
+    // 중복 제거: 동일한 riotName과 riotTag를 가진 항목 제거
+    const filtered = recentSearches.filter(
+      (item) => !(item.riotName === search.riotName && item.riotTag === search.riotTag)
+    );
+
+    // 맨 앞에 새 검색어 추가
+    const updated = [search, ...filtered];
+
+    // 최대 개수만큼만 유지
+    const limited = updated.slice(0, MAX_RECENT_SEARCHES);
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(limited));
+  } catch (error) {
+    console.error("Failed to save recent search:", error);
+  }
+};
+
+/**
+ * 특정 최근 검색어를 삭제
+ */
+export const removeRecentSearch = (riotName: string, riotTag: string): void => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    const recentSearches = getRecentSearches();
+    const filtered = recentSearches.filter(
+      (item) => !(item.riotName === riotName && item.riotTag === riotTag)
+    );
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
+  } catch (error) {
+    console.error("Failed to remove recent search:", error);
+  }
+};
+
+/**
+ * 모든 최근 검색어를 삭제
+ */
+export const clearRecentSearches = (): void => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch (error) {
+    console.error("Failed to clear recent searches:", error);
+  }
+};


### PR DESCRIPTION
### 📋 수정된 사항
- 난민클랜 유저통계 20판넘었는데 안나오는 버그 → 버그 아니었음
- 전적 검색 대시보드 페이지 배경 챔피언 이미지 맞춤
- 모스트픽 챔피언 글자 오른쪽 정렬 > 왼쪽 정렬 변경
- 전적 검색 상세 페이지 챔피언, 소환사명 위치 변경 및 왼쪽정렬
- 검색에 최근검색어, 즐겨찾기, 연관검색어 (연관검색어는있음) 만들기
- 유저 통계에서 전체를 분리하기
- 영어로 기재되어있던 항목명 한국어로 수정
- 필준님께서 리포팅해주신 유저분석 버그 수정
  - -> 전체 탭의 데이터가 라인 상관없는 통계로 보여주도록 데이터가 변경되어서, 라인 아이콘을 제거
- 유저 전적에 포지션 승률, 팀워크 항목 추가
- 유저 전적 화면 배경에 모스트 1위 챔피언 이미지 삽입
- 아이템, 스펠, 룬 툴팁 추가