### PR TITLE
[TRC-203] 통계 페이지 조건 및 UI 개선

### DIFF
--- a/src/features/statistics/ChampionRankHeader.tsx
+++ b/src/features/statistics/ChampionRankHeader.tsx
@@ -1,36 +1,53 @@
+type SortBy = "totalGames" | "winRate";
+type SortOrder = "asc" | "desc";
+
 interface Props {
   className?: string;
+  sortBy: SortBy;
+  sortOrder: SortOrder;
+  onSort: (column: SortBy) => void;
 }
 
-const ChampionRankHeader = ({ className }: Props) => {
+const ChampionRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => {
+  const getSortIndicator = (column: SortBy) => {
+    if (sortBy !== column) return null;
+    return sortOrder === "asc" ? " ▲" : " ▼";
+  };
+
   return (
     <div className={`hidden md:flex items-center gap-3 px-3 py-2 ${className || ""}`}>
       {/* 랭크 */}
-      <div className="flex-shrink-0 w-8 text-center">
-        <span className="text-sm font-medium text-primary2" />
-      </div>
+      <div className="flex-shrink-0 w-8 text-center" />
 
       {/* 챔피언 아이콘 (빈 공간) */}
       <div className="flex-shrink-0 w-12" />
 
       {/* 챔피언 이름 */}
-      <div className="flex-1 min-w-0">
-        <span className="text-sm font-medium text-primary2" />
-      </div>
+      <div className="flex-1 min-w-0" />
 
       {/* 라인 */}
-      <div className="flex-shrink-0 w-10 text-center">
-        <span className="text-sm font-medium text-primary2" />
-      </div>
+      <div className="flex-shrink-0 w-12 text-center" />
 
       {/* 승률 */}
       <div className="flex-shrink-0 w-20 text-center">
-        <span className="text-sm font-medium text-primary2">승률</span>
+        <button
+          type="button"
+          onClick={() => onSort("winRate")}
+          className="text-sm font-medium text-primary2 hover:text-primary1 transition-colors cursor-pointer"
+        >
+          승률{getSortIndicator("winRate")}
+        </button>
       </div>
 
       {/* 게임 수 */}
       <div className="flex-shrink-0 w-20 text-center">
-        <span className="text-sm font-medium text-primary2">게임 수</span>
+        <button
+          type="button"
+          onClick={() => onSort("totalGames")}
+          className="text-sm font-medium text-primary2 hover:text-primary1 transition-colors cursor-pointer"
+        >
+          게임 수{getSortIndicator("totalGames")}
+        </button>
       </div>
     </div>
   );

--- a/src/pages/champion/index.tsx
+++ b/src/pages/champion/index.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from "next";
 import SummonerPageHeader from "@/components/layout/SummonerPageHeader";
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import useUserSearchController from "@/hooks/searchUserList/useUserSearchController";
 import useGuildManagement from "@/hooks/auth/useGuildManagement";
 import TitleBox from "@/components/ui/TitleBox";
@@ -14,6 +14,8 @@ import { ChampionStatisticsResponse } from "@/data/types/statistics";
 import TextCard from "@/components/ui/TextCard";
 
 type DateMode = "recent" | "season" | "range";
+type SortBy = "totalGames" | "winRate";
+type SortOrder = "asc" | "desc";
 
 const now = new Date();
 const CURRENT_YEAR = now.getFullYear();
@@ -45,6 +47,8 @@ const Champion: NextPage = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedPosition, setSelectedPosition] = useState<Position>("ALL");
   const [displayCount, setDisplayCount] = useState(10);
+  const [sortBy, setSortBy] = useState<SortBy>("winRate");
+  const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
   const [dateMode, setDateMode] = useState<DateMode>("recent");
   const [selectedSeason, setSelectedSeason] = useState(String(CURRENT_YEAR));
   const [draftRangeSeason, setDraftRangeSeason] = useState(String(CURRENT_YEAR));
@@ -102,6 +106,15 @@ const Champion: NextPage = () => {
     placeholderData: undefined,
   });
 
+  const handleSort = (column: SortBy) => {
+    if (sortBy === column) {
+      setSortOrder(sortOrder === "asc" ? "desc" : "asc");
+    } else {
+      setSortBy(column);
+      setSortOrder("desc");
+    }
+  };
+
   const handleApplyRange = () => {
     const from = Math.min(draftFromMonth, draftToMonth);
     const to = Math.max(draftFromMonth, draftToMonth);
@@ -110,22 +123,40 @@ const Champion: NextPage = () => {
     setAppliedRange({ season: draftRangeSeason, fromMonth: from, toMonth: to });
   };
 
-  const allChampions = championStatisticsData?.data?.data || [];
-  const displayedChampions = allChampions.slice(0, displayCount);
-  const hasMore = allChampions.length > displayCount;
-  hasMoreRef.current = hasMore;
+  const allChampions = useMemo(
+    () => championStatisticsData?.data?.data || [],
+    [championStatisticsData]
+  );
 
-  const popularChampions = [...allChampions]
-    .sort((a, b) => b.totalCount - a.totalCount)
-    .slice(0, 10)
-    .map((c) => c.champNameEng);
+  const popularChampions = useMemo(
+    () =>
+      [...allChampions]
+        .sort((a, b) => b.totalCount - a.totalCount)
+        .slice(0, 10)
+        .map((c) => c.champNameEng),
+    [allChampions]
+  );
+
+  const sortedChampions = useMemo(() => {
+    const champions = [...allChampions];
+    champions.sort((a, b) => {
+      const aValue = sortBy === "totalGames" ? a.totalCount : parseFloat(a.winRate) || 0;
+      const bValue = sortBy === "totalGames" ? b.totalCount : parseFloat(b.winRate) || 0;
+      return sortOrder === "asc" ? aValue - bValue : bValue - aValue;
+    });
+    return champions;
+  }, [allChampions, sortBy, sortOrder]);
+
+  const displayedChampions = sortedChampions.slice(0, displayCount);
+  const hasMore = sortedChampions.length > displayCount;
+  hasMoreRef.current = hasMore;
 
   const selectedGuild = guilds.find((guild) => guild.id === guildId);
   const clanName = selectedGuild?.name || "클랜";
 
   useEffect(() => {
     setDisplayCount(10);
-  }, [selectedPosition, dateMode, querySeason, queryFromMonth, queryToMonth]);
+  }, [selectedPosition, dateMode, querySeason, queryFromMonth, queryToMonth, sortBy, sortOrder]);
 
   const sentinelRef = useCallback((node: HTMLDivElement | null) => {
     if (observerInstance.current) {
@@ -279,7 +310,7 @@ const Champion: NextPage = () => {
       />
 
       <div className="mt-1">
-        <ChampionRankHeader />
+        <ChampionRankHeader sortBy={sortBy} sortOrder={sortOrder} onSort={handleSort} />
         <div key={selectedPosition} className="space-y-3 mt-2">
           {(() => {
             if (!isLoggedIn) {
@@ -303,7 +334,7 @@ const Champion: NextPage = () => {
                 )}
 
                 {!(isErrorStatistics || isLoadingStatistics || isFetchingStatistics) &&
-                  allChampions.length > 0 && (
+                  sortedChampions.length > 0 && (
                     <>
                       {displayedChampions.map((champion, index) => {
                         const rank = index + 1;
@@ -338,7 +369,7 @@ const Champion: NextPage = () => {
 
                 {!(isErrorStatistics || isLoadingStatistics || isFetchingStatistics) &&
                   isFetchedStatistics &&
-                  allChampions.length === 0 && (
+                  sortedChampions.length === 0 && (
                     <div className="text-center py-10 text-primary2 bg-darkBg2 rounded border border-border2">
                       5판 이상 플레이한 챔피언이 없어 통계 데이터를 확인할 수 없습니다.
                     </div>

--- a/src/pages/champion/index.tsx
+++ b/src/pages/champion/index.tsx
@@ -125,7 +125,7 @@ const Champion: NextPage = () => {
 
   useEffect(() => {
     setDisplayCount(10);
-  }, [selectedPosition]);
+  }, [selectedPosition, dateMode, querySeason, queryFromMonth, queryToMonth]);
 
   const sentinelRef = useCallback((node: HTMLDivElement | null) => {
     if (observerInstance.current) {

--- a/src/pages/champion/index.tsx
+++ b/src/pages/champion/index.tsx
@@ -8,30 +8,53 @@ import PositionFilter from "@/features/statistics/PositionFilter";
 import ChampionRankHeader from "@/features/statistics/ChampionRankHeader";
 import ChampionRankItem from "@/features/statistics/ChampionRankItem";
 import { useQuery } from "@tanstack/react-query";
-import { getChampionStatistics, Position } from "@/services/statistics";
+import { getChampionStatistics, Position, DatePreset } from "@/services/statistics";
 import { ApiResponse } from "@/services/apiService";
 import { ChampionStatisticsResponse } from "@/data/types/statistics";
 import TextCard from "@/components/ui/TextCard";
 
-type DateMode = "recent" | "monthly";
+type DateMode = "recent" | "season" | "range";
 
 const now = new Date();
 const CURRENT_YEAR = now.getFullYear();
 const CURRENT_MONTH = now.getMonth() + 1;
 const START_YEAR = 2024;
-const YEAR_OPTIONS = Array.from(
-  { length: CURRENT_YEAR - START_YEAR + 1 },
-  (_, i) => START_YEAR + i
+const SEASON_OPTIONS = Array.from({ length: CURRENT_YEAR - START_YEAR + 1 }, (_, i) =>
+  String(START_YEAR + i)
 );
 const MONTH_OPTIONS = Array.from({ length: 12 }, (_, i) => i + 1);
+
+const ChevronDown = () => (
+  <div className="pointer-events-none absolute inset-y-0 right-2.5 flex items-center">
+    <svg
+      className="w-3 h-3 text-primary2"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2.5}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+    </svg>
+  </div>
+);
+
+const SELECT_CLASS =
+  "appearance-none bg-rankBg2 border border-border1 hover:border-blueText2 rounded-lg pl-3 pr-8 py-1.5 text-sm text-primary1 cursor-pointer focus:outline-none focus:border-blueText2 transition-colors duration-150";
 
 const Champion: NextPage = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedPosition, setSelectedPosition] = useState<Position>("ALL");
   const [displayCount, setDisplayCount] = useState(10);
   const [dateMode, setDateMode] = useState<DateMode>("recent");
-  const [selectedYear, setSelectedYear] = useState(CURRENT_YEAR);
-  const [selectedMonth, setSelectedMonth] = useState(CURRENT_MONTH);
+  const [selectedSeason, setSelectedSeason] = useState(String(CURRENT_YEAR));
+  const [draftRangeSeason, setDraftRangeSeason] = useState(String(CURRENT_YEAR));
+  const [draftFromMonth, setDraftFromMonth] = useState(1);
+  const [draftToMonth, setDraftToMonth] = useState(CURRENT_MONTH);
+  const [appliedRange, setAppliedRange] = useState({
+    season: String(CURRENT_YEAR),
+    fromMonth: 1,
+    toMonth: CURRENT_MONTH,
+  });
   const observerInstance = useRef<IntersectionObserver | null>(null);
   const hasMoreRef = useRef(false);
   const { guildId, guilds, isLoggedIn, username, handleGuildChange } = useGuildManagement();
@@ -42,8 +65,11 @@ const Champion: NextPage = () => {
     handleSearchButtonClick,
   } = useUserSearchController(searchTerm, guildId);
 
-  const queryYear = dateMode === "monthly" ? selectedYear : undefined;
-  const queryMonth = dateMode === "monthly" ? selectedMonth : undefined;
+  let querySeason: string | undefined;
+  if (dateMode === "season") querySeason = selectedSeason;
+  else if (dateMode === "range") querySeason = appliedRange.season;
+  const queryFromMonth = dateMode === "range" ? appliedRange.fromMonth : undefined;
+  const queryToMonth = dateMode === "range" ? appliedRange.toMonth : undefined;
 
   const {
     data: championStatisticsData,
@@ -52,35 +78,55 @@ const Champion: NextPage = () => {
     isFetched: isFetchedStatistics,
     isError: isErrorStatistics,
   } = useQuery<ApiResponse<ChampionStatisticsResponse>>({
-    queryKey: ["championStatistics", guildId, selectedPosition, dateMode, queryYear, queryMonth],
-    queryFn: () => getChampionStatistics(guildId, selectedPosition, queryYear, queryMonth),
+    queryKey: [
+      "championStatistics",
+      guildId,
+      selectedPosition,
+      dateMode,
+      querySeason,
+      queryFromMonth,
+      queryToMonth,
+    ],
+    queryFn: () =>
+      getChampionStatistics(
+        guildId,
+        selectedPosition,
+        dateMode as DatePreset,
+        querySeason,
+        queryFromMonth,
+        queryToMonth
+      ),
     enabled: !!guildId,
     staleTime: 10 * 60 * 1000,
     structuralSharing: false,
     placeholderData: undefined,
   });
 
+  const handleApplyRange = () => {
+    const from = Math.min(draftFromMonth, draftToMonth);
+    const to = Math.max(draftFromMonth, draftToMonth);
+    setDraftFromMonth(from);
+    setDraftToMonth(to);
+    setAppliedRange({ season: draftRangeSeason, fromMonth: from, toMonth: to });
+  };
+
   const allChampions = championStatisticsData?.data?.data || [];
   const displayedChampions = allChampions.slice(0, displayCount);
   const hasMore = allChampions.length > displayCount;
   hasMoreRef.current = hasMore;
 
-  // 게임 수 상위 10위 챔피언 계산
   const popularChampions = [...allChampions]
     .sort((a, b) => b.totalCount - a.totalCount)
     .slice(0, 10)
     .map((c) => c.champNameEng);
 
-  // 현재 선택된 클랜 이름 가져오기
   const selectedGuild = guilds.find((guild) => guild.id === guildId);
   const clanName = selectedGuild?.name || "클랜";
 
-  // 포지션 변경 시 displayCount 리셋
   useEffect(() => {
     setDisplayCount(10);
   }, [selectedPosition]);
 
-  // 무한 스크롤 - callback ref: sentinel이 DOM에 마운트되는 순간 즉시 등록
   const sentinelRef = useCallback((node: HTMLDivElement | null) => {
     if (observerInstance.current) {
       observerInstance.current.disconnect();
@@ -120,98 +166,110 @@ const Champion: NextPage = () => {
         description="챔피언 플레이 기록이 5판 이상인 경우에만 통계에 표시"
       />
 
-      {/* 기간 선택 토글 + 드롭다운 */}
+      {/* 기간 선택 */}
       <div className="flex flex-wrap items-center gap-3 mt-3">
-        {/* 세그먼트 컨트롤 토글 */}
+        {/* 3-way 토글 */}
         <div className="flex p-0.5 rounded-lg bg-rankBg1 border border-border1">
-          <button
-            type="button"
-            onClick={() => setDateMode("recent")}
-            className={`px-4 py-1.5 rounded-md text-sm font-medium transition-all duration-200 ${
-              dateMode === "recent"
-                ? "bg-primary1 text-darkBg2 shadow"
-                : "text-primary2 hover:text-primary1"
-            }`}
-          >
-            최근 1개월
-          </button>
-          <button
-            type="button"
-            onClick={() => setDateMode("monthly")}
-            className={`px-4 py-1.5 rounded-md text-sm font-medium transition-all duration-200 ${
-              dateMode === "monthly"
-                ? "bg-primary1 text-darkBg2 shadow"
-                : "text-primary2 hover:text-primary1"
-            }`}
-          >
-            월별
-          </button>
+          {(["recent", "season", "range"] as DateMode[]).map((mode) => {
+            const labels: Record<DateMode, string> = {
+              recent: "최근",
+              season: "시즌 전적",
+              range: "기간 선택",
+            };
+            return (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => setDateMode(mode)}
+                className={`px-3 py-1.5 rounded-md text-sm font-medium transition-all duration-200 ${
+                  dateMode === mode
+                    ? "bg-primary1 text-darkBg2 shadow"
+                    : "text-primary2 hover:text-primary1"
+                }`}
+              >
+                {labels[mode]}
+              </button>
+            );
+          })}
         </div>
 
-        {/* 구분선 */}
-        <div className="hidden sm:block h-5 w-px bg-border1" />
+        {/* 시즌 전적 - 시즌 선택 */}
+        {dateMode === "season" && (
+          <>
+            <div className="hidden sm:block h-5 w-px bg-border1" />
+            <div className="relative">
+              <select
+                value={selectedSeason}
+                onChange={(e) => setSelectedSeason(e.target.value)}
+                className={SELECT_CLASS}
+              >
+                {SEASON_OPTIONS.map((s) => (
+                  <option key={s} value={s}>
+                    {s} 시즌
+                  </option>
+                ))}
+              </select>
+              <ChevronDown />
+            </div>
+          </>
+        )}
 
-        {/* 연도 드롭다운 */}
-        <div
-          className={`relative transition-opacity duration-200 ${
-            dateMode === "recent" ? "opacity-30 pointer-events-none" : "opacity-100"
-          }`}
-        >
-          <select
-            value={selectedYear}
-            onChange={(e) => setSelectedYear(Number(e.target.value))}
-            disabled={dateMode === "recent"}
-            className="appearance-none bg-rankBg2 border border-border1 hover:border-blueText2 rounded-lg pl-3 pr-8 py-1.5 text-sm text-primary1 cursor-pointer focus:outline-none focus:border-blueText2 transition-colors duration-150"
-          >
-            {YEAR_OPTIONS.map((year) => (
-              <option key={year} value={year}>
-                {year}년
-              </option>
-            ))}
-          </select>
-          <div className="pointer-events-none absolute inset-y-0 right-2.5 flex items-center">
-            <svg
-              className="w-3 h-3 text-primary2"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2.5}
+        {/* 기간 선택 - 시즌 + 시작 월 + 끝 월 + 적용 */}
+        {dateMode === "range" && (
+          <>
+            <div className="hidden sm:block h-5 w-px bg-border1" />
+            <div className="relative">
+              <select
+                value={draftRangeSeason}
+                onChange={(e) => setDraftRangeSeason(e.target.value)}
+                className={SELECT_CLASS}
+              >
+                {SEASON_OPTIONS.map((s) => (
+                  <option key={s} value={s}>
+                    {s} 시즌
+                  </option>
+                ))}
+              </select>
+              <ChevronDown />
+            </div>
+            <div className="relative">
+              <select
+                value={draftFromMonth}
+                onChange={(e) => setDraftFromMonth(Number(e.target.value))}
+                className={SELECT_CLASS}
+              >
+                {MONTH_OPTIONS.map((m) => (
+                  <option key={m} value={m}>
+                    {m}월
+                  </option>
+                ))}
+              </select>
+              <ChevronDown />
+            </div>
+            <span className="text-primary2 text-sm">~</span>
+            <div className="relative">
+              <select
+                value={draftToMonth}
+                onChange={(e) => setDraftToMonth(Number(e.target.value))}
+                className={SELECT_CLASS}
+              >
+                {MONTH_OPTIONS.map((m) => (
+                  <option key={m} value={m}>
+                    {m}월
+                  </option>
+                ))}
+              </select>
+              <ChevronDown />
+            </div>
+            <button
+              type="button"
+              onClick={handleApplyRange}
+              className="px-3 py-1.5 rounded-lg text-sm font-medium bg-blueButton hover:bg-blueText2 text-white transition-colors duration-150"
             >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-            </svg>
-          </div>
-        </div>
-
-        {/* 월 드롭다운 */}
-        <div
-          className={`relative transition-opacity duration-200 ${
-            dateMode === "recent" ? "opacity-30 pointer-events-none" : "opacity-100"
-          }`}
-        >
-          <select
-            value={selectedMonth}
-            onChange={(e) => setSelectedMonth(Number(e.target.value))}
-            disabled={dateMode === "recent"}
-            className="appearance-none bg-rankBg2 border border-border1 hover:border-blueText2 rounded-lg pl-3 pr-8 py-1.5 text-sm text-primary1 cursor-pointer focus:outline-none focus:border-blueText2 transition-colors duration-150"
-          >
-            {MONTH_OPTIONS.map((month) => (
-              <option key={month} value={month}>
-                {month}월
-              </option>
-            ))}
-          </select>
-          <div className="pointer-events-none absolute inset-y-0 right-2.5 flex items-center">
-            <svg
-              className="w-3 h-3 text-primary2"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2.5}
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-            </svg>
-          </div>
-        </div>
+              적용
+            </button>
+          </>
+        )}
       </div>
 
       <PositionFilter
@@ -224,12 +282,10 @@ const Champion: NextPage = () => {
         <ChampionRankHeader />
         <div key={selectedPosition} className="space-y-3 mt-2">
           {(() => {
-            // 비로그인 상태
             if (!isLoggedIn) {
               return <TextCard text="로그인 후 이용해주세요" />;
             }
 
-            // 소속 클랜 없음
             if (guilds.length === 0) {
               return <TextCard text="소속된 클랜이 없습니다" />;
             }
@@ -253,15 +309,13 @@ const Champion: NextPage = () => {
                         const rank = index + 1;
                         const totalChampions = allChampions.length;
 
-                        // 티어 계산 (겹치지 않을 때만 부여)
                         let tier: 1 | 5 | undefined;
                         if (rank <= 10 && totalChampions - rank >= 10) {
-                          tier = 1; // 승률 상위 10위
+                          tier = 1;
                         } else if (totalChampions - rank < 10 && rank > 10) {
-                          tier = 5; // 승률 하위 10위
+                          tier = 5;
                         }
 
-                        // 인기 여부 계산
                         const isPopular = popularChampions.includes(champion.champNameEng);
 
                         return (
@@ -278,7 +332,6 @@ const Champion: NextPage = () => {
                           />
                         );
                       })}
-                      {/* 무한 스크롤 트리거 */}
                       {hasMore && <div ref={sentinelRef} className="h-10" />}
                     </>
                   )}

--- a/src/pages/champion/index.tsx
+++ b/src/pages/champion/index.tsx
@@ -123,29 +123,24 @@ const Champion: NextPage = () => {
     setAppliedRange({ season: draftRangeSeason, fromMonth: from, toMonth: to });
   };
 
-  const allChampions = useMemo(
-    () => championStatisticsData?.data?.data || [],
-    [championStatisticsData]
-  );
-
   const popularChampions = useMemo(
     () =>
-      [...allChampions]
+      [...(championStatisticsData?.data?.data || [])]
         .sort((a, b) => b.totalCount - a.totalCount)
         .slice(0, 10)
         .map((c) => c.champNameEng),
-    [allChampions]
+    [championStatisticsData?.data?.data]
   );
 
   const sortedChampions = useMemo(() => {
-    const champions = [...allChampions];
+    const champions = [...(championStatisticsData?.data?.data || [])];
     champions.sort((a, b) => {
       const aValue = sortBy === "totalGames" ? a.totalCount : parseFloat(a.winRate) || 0;
       const bValue = sortBy === "totalGames" ? b.totalCount : parseFloat(b.winRate) || 0;
       return sortOrder === "asc" ? aValue - bValue : bValue - aValue;
     });
     return champions;
-  }, [allChampions, sortBy, sortOrder]);
+  }, [championStatisticsData?.data?.data, sortBy, sortOrder]);
 
   const displayedChampions = sortedChampions.slice(0, displayCount);
   const hasMore = sortedChampions.length > displayCount;
@@ -338,7 +333,7 @@ const Champion: NextPage = () => {
                     <>
                       {displayedChampions.map((champion, index) => {
                         const rank = index + 1;
-                        const totalChampions = allChampions.length;
+                        const totalChampions = sortedChampions.length;
 
                         let tier: 1 | 5 | undefined;
                         if (rank <= 10 && totalChampions - rank >= 10) {

--- a/src/pages/champion/index.tsx
+++ b/src/pages/champion/index.tsx
@@ -151,7 +151,7 @@ const Champion: NextPage = () => {
 
   useEffect(() => {
     setDisplayCount(10);
-  }, [selectedPosition, dateMode, querySeason, queryFromMonth, queryToMonth, sortBy, sortOrder]);
+  }, [selectedPosition, dateMode, querySeason, queryFromMonth, queryToMonth]);
 
   const sentinelRef = useCallback((node: HTMLDivElement | null) => {
     if (observerInstance.current) {
@@ -346,7 +346,7 @@ const Champion: NextPage = () => {
 
                         return (
                           <ChampionRankItem
-                            key={champion.champNameEng}
+                            key={`${champion.champNameEng}_${champion.position}`}
                             rank={rank}
                             championName={champion.champName}
                             championNameEng={champion.champNameEng}

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -157,7 +157,7 @@ const User: NextPage = () => {
 
   useEffect(() => {
     setDisplayCount(10);
-  }, [selectedPosition]);
+  }, [selectedPosition, dateMode, querySeason, queryFromMonth, queryToMonth]);
 
   const sentinelRef = useCallback((node: HTMLDivElement | null) => {
     if (observerInstance.current) {

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -8,12 +8,12 @@ import PositionFilter from "@/features/statistics/PositionFilter";
 import UserRankHeader from "@/features/statistics/UserRankHeader";
 import UserRankItem from "@/features/statistics/UserRankItem";
 import { useQuery } from "@tanstack/react-query";
-import { getUserStatistics, Position } from "@/services/statistics";
+import { getUserStatistics, Position, DatePreset } from "@/services/statistics";
 import { ApiResponse } from "@/services/apiService";
 import { UserStatisticsResponse } from "@/data/types/statistics";
 import TextCard from "@/components/ui/TextCard";
 
-type DateMode = "recent" | "monthly";
+type DateMode = "recent" | "season" | "range";
 type SortBy = "totalGames" | "winRate";
 type SortOrder = "asc" | "desc";
 
@@ -21,11 +21,27 @@ const now = new Date();
 const CURRENT_YEAR = now.getFullYear();
 const CURRENT_MONTH = now.getMonth() + 1;
 const START_YEAR = 2024;
-const YEAR_OPTIONS = Array.from(
-  { length: CURRENT_YEAR - START_YEAR + 1 },
-  (_, i) => START_YEAR + i
+const SEASON_OPTIONS = Array.from({ length: CURRENT_YEAR - START_YEAR + 1 }, (_, i) =>
+  String(START_YEAR + i)
 );
 const MONTH_OPTIONS = Array.from({ length: 12 }, (_, i) => i + 1);
+
+const ChevronDown = () => (
+  <div className="pointer-events-none absolute inset-y-0 right-2.5 flex items-center">
+    <svg
+      className="w-3 h-3 text-primary2"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2.5}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+    </svg>
+  </div>
+);
+
+const SELECT_CLASS =
+  "appearance-none bg-rankBg2 border border-border1 hover:border-blueText2 rounded-lg pl-3 pr-8 py-1.5 text-sm text-primary1 cursor-pointer focus:outline-none focus:border-blueText2 transition-colors duration-150";
 
 const User: NextPage = () => {
   const [searchTerm, setSearchTerm] = useState("");
@@ -34,8 +50,15 @@ const User: NextPage = () => {
   const [sortBy, setSortBy] = useState<SortBy>("winRate");
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
   const [dateMode, setDateMode] = useState<DateMode>("recent");
-  const [selectedYear, setSelectedYear] = useState(CURRENT_YEAR);
-  const [selectedMonth, setSelectedMonth] = useState(CURRENT_MONTH);
+  const [selectedSeason, setSelectedSeason] = useState(String(CURRENT_YEAR));
+  const [draftRangeSeason, setDraftRangeSeason] = useState(String(CURRENT_YEAR));
+  const [draftFromMonth, setDraftFromMonth] = useState(1);
+  const [draftToMonth, setDraftToMonth] = useState(CURRENT_MONTH);
+  const [appliedRange, setAppliedRange] = useState({
+    season: String(CURRENT_YEAR),
+    fromMonth: 1,
+    toMonth: CURRENT_MONTH,
+  });
   const observerInstance = useRef<IntersectionObserver | null>(null);
   const hasMoreRef = useRef(false);
 
@@ -47,8 +70,11 @@ const User: NextPage = () => {
     handleSearchButtonClick,
   } = useUserSearchController(searchTerm, guildId);
 
-  const queryYear = dateMode === "monthly" ? selectedYear : undefined;
-  const queryMonth = dateMode === "monthly" ? selectedMonth : undefined;
+  let querySeason: string | undefined;
+  if (dateMode === "season") querySeason = selectedSeason;
+  else if (dateMode === "range") querySeason = appliedRange.season;
+  const queryFromMonth = dateMode === "range" ? appliedRange.fromMonth : undefined;
+  const queryToMonth = dateMode === "range" ? appliedRange.toMonth : undefined;
 
   const {
     data: userStatisticsData,
@@ -57,18 +83,32 @@ const User: NextPage = () => {
     isFetched: isFetchedStatistics,
     isError: isErrorStatistics,
   } = useQuery<ApiResponse<UserStatisticsResponse>>({
-    queryKey: ["userStatistics", guildId, selectedPosition, dateMode, queryYear, queryMonth],
-    queryFn: () => getUserStatistics(guildId, selectedPosition, queryYear, queryMonth),
+    queryKey: [
+      "userStatistics",
+      guildId,
+      selectedPosition,
+      dateMode,
+      querySeason,
+      queryFromMonth,
+      queryToMonth,
+    ],
+    queryFn: () =>
+      getUserStatistics(
+        guildId,
+        selectedPosition,
+        dateMode as DatePreset,
+        querySeason,
+        queryFromMonth,
+        queryToMonth
+      ),
     enabled: !!guildId,
-    staleTime: 5 * 60 * 1000, // 5분
+    staleTime: 5 * 60 * 1000,
     structuralSharing: false,
     placeholderData: undefined,
   });
 
-  // 정렬 핸들러
   const handleSort = (column: SortBy) => {
     if (sortBy === column) {
-      // 같은 컬럼 선택 시
       setSortOrder(sortOrder === "asc" ? "desc" : "asc");
     } else {
       setSortBy(column);
@@ -76,7 +116,14 @@ const User: NextPage = () => {
     }
   };
 
-  // 정렬된 사용자 목록
+  const handleApplyRange = () => {
+    const from = Math.min(draftFromMonth, draftToMonth);
+    const to = Math.max(draftFromMonth, draftToMonth);
+    setDraftFromMonth(from);
+    setDraftToMonth(to);
+    setAppliedRange({ season: draftRangeSeason, fromMonth: from, toMonth: to });
+  };
+
   const sortedUsers = useMemo(() => {
     const users = [...(userStatisticsData?.data?.data || [])];
 
@@ -88,7 +135,6 @@ const User: NextPage = () => {
         aValue = a.totalCount || 0;
         bValue = b.totalCount || 0;
       } else {
-        // winRate
         aValue = parseFloat(a.winRate) || 0;
         bValue = parseFloat(b.winRate) || 0;
       }
@@ -106,16 +152,13 @@ const User: NextPage = () => {
   const hasMore = sortedUsers.length > displayCount;
   hasMoreRef.current = hasMore;
 
-  // 현재 선택된 클랜 이름 가져오기
   const selectedGuild = guilds.find((guild) => guild.id === guildId);
   const clanName = selectedGuild?.name || "클랜";
 
-  // 포지션 변경 시 displayCount 리셋
   useEffect(() => {
     setDisplayCount(10);
   }, [selectedPosition]);
 
-  // 무한 스크롤 - callback ref: sentinel이 DOM에 마운트되는 순간 즉시 등록
   const sentinelRef = useCallback((node: HTMLDivElement | null) => {
     if (observerInstance.current) {
       observerInstance.current.disconnect();
@@ -156,98 +199,110 @@ const User: NextPage = () => {
         description="내전 플레이 기록이 5판 이상인 경우에만 통계에 표시"
       />
 
-      {/* 기간 선택 토글 + 드롭다운 */}
+      {/* 기간 선택 */}
       <div className="flex flex-wrap items-center gap-3 mt-3">
-        {/* 세그먼트 컨트롤 토글 */}
+        {/* 3-way 토글 */}
         <div className="flex p-0.5 rounded-lg bg-rankBg1 border border-border1">
-          <button
-            type="button"
-            onClick={() => setDateMode("recent")}
-            className={`px-4 py-1.5 rounded-md text-sm font-medium transition-all duration-200 ${
-              dateMode === "recent"
-                ? "bg-primary1 text-darkBg2 shadow"
-                : "text-primary2 hover:text-primary1"
-            }`}
-          >
-            최근 1개월
-          </button>
-          <button
-            type="button"
-            onClick={() => setDateMode("monthly")}
-            className={`px-4 py-1.5 rounded-md text-sm font-medium transition-all duration-200 ${
-              dateMode === "monthly"
-                ? "bg-primary1 text-darkBg2 shadow"
-                : "text-primary2 hover:text-primary1"
-            }`}
-          >
-            월별
-          </button>
+          {(["recent", "season", "range"] as DateMode[]).map((mode) => {
+            const labels: Record<DateMode, string> = {
+              recent: "최근",
+              season: "시즌 전적",
+              range: "기간 선택",
+            };
+            return (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => setDateMode(mode)}
+                className={`px-3 py-1.5 rounded-md text-sm font-medium transition-all duration-200 ${
+                  dateMode === mode
+                    ? "bg-primary1 text-darkBg2 shadow"
+                    : "text-primary2 hover:text-primary1"
+                }`}
+              >
+                {labels[mode]}
+              </button>
+            );
+          })}
         </div>
 
-        {/* 구분선 */}
-        <div className="hidden sm:block h-5 w-px bg-border1" />
+        {/* 시즌 전적 - 시즌 선택 */}
+        {dateMode === "season" && (
+          <>
+            <div className="hidden sm:block h-5 w-px bg-border1" />
+            <div className="relative">
+              <select
+                value={selectedSeason}
+                onChange={(e) => setSelectedSeason(e.target.value)}
+                className={SELECT_CLASS}
+              >
+                {SEASON_OPTIONS.map((s) => (
+                  <option key={s} value={s}>
+                    {s} 시즌
+                  </option>
+                ))}
+              </select>
+              <ChevronDown />
+            </div>
+          </>
+        )}
 
-        {/* 연도 드롭다운 */}
-        <div
-          className={`relative transition-opacity duration-200 ${
-            dateMode === "recent" ? "opacity-30 pointer-events-none" : "opacity-100"
-          }`}
-        >
-          <select
-            value={selectedYear}
-            onChange={(e) => setSelectedYear(Number(e.target.value))}
-            disabled={dateMode === "recent"}
-            className="appearance-none bg-rankBg2 border border-border1 hover:border-blueText2 rounded-lg pl-3 pr-8 py-1.5 text-sm text-primary1 cursor-pointer focus:outline-none focus:border-blueText2 transition-colors duration-150"
-          >
-            {YEAR_OPTIONS.map((year) => (
-              <option key={year} value={year}>
-                {year}년
-              </option>
-            ))}
-          </select>
-          <div className="pointer-events-none absolute inset-y-0 right-2.5 flex items-center">
-            <svg
-              className="w-3 h-3 text-primary2"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2.5}
+        {/* 기간 선택 - 시즌 + 시작 월 + 끝 월 + 적용 */}
+        {dateMode === "range" && (
+          <>
+            <div className="hidden sm:block h-5 w-px bg-border1" />
+            <div className="relative">
+              <select
+                value={draftRangeSeason}
+                onChange={(e) => setDraftRangeSeason(e.target.value)}
+                className={SELECT_CLASS}
+              >
+                {SEASON_OPTIONS.map((s) => (
+                  <option key={s} value={s}>
+                    {s} 시즌
+                  </option>
+                ))}
+              </select>
+              <ChevronDown />
+            </div>
+            <div className="relative">
+              <select
+                value={draftFromMonth}
+                onChange={(e) => setDraftFromMonth(Number(e.target.value))}
+                className={SELECT_CLASS}
+              >
+                {MONTH_OPTIONS.map((m) => (
+                  <option key={m} value={m}>
+                    {m}월
+                  </option>
+                ))}
+              </select>
+              <ChevronDown />
+            </div>
+            <span className="text-primary2 text-sm">~</span>
+            <div className="relative">
+              <select
+                value={draftToMonth}
+                onChange={(e) => setDraftToMonth(Number(e.target.value))}
+                className={SELECT_CLASS}
+              >
+                {MONTH_OPTIONS.map((m) => (
+                  <option key={m} value={m}>
+                    {m}월
+                  </option>
+                ))}
+              </select>
+              <ChevronDown />
+            </div>
+            <button
+              type="button"
+              onClick={handleApplyRange}
+              className="px-3 py-1.5 rounded-lg text-sm font-medium bg-blueButton hover:bg-blueText2 text-white transition-colors duration-150"
             >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-            </svg>
-          </div>
-        </div>
-
-        {/* 월 드롭다운 */}
-        <div
-          className={`relative transition-opacity duration-200 ${
-            dateMode === "recent" ? "opacity-30 pointer-events-none" : "opacity-100"
-          }`}
-        >
-          <select
-            value={selectedMonth}
-            onChange={(e) => setSelectedMonth(Number(e.target.value))}
-            disabled={dateMode === "recent"}
-            className="appearance-none bg-rankBg2 border border-border1 hover:border-blueText2 rounded-lg pl-3 pr-8 py-1.5 text-sm text-primary1 cursor-pointer focus:outline-none focus:border-blueText2 transition-colors duration-150"
-          >
-            {MONTH_OPTIONS.map((month) => (
-              <option key={month} value={month}>
-                {month}월
-              </option>
-            ))}
-          </select>
-          <div className="pointer-events-none absolute inset-y-0 right-2.5 flex items-center">
-            <svg
-              className="w-3 h-3 text-primary2"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2.5}
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-            </svg>
-          </div>
-        </div>
+              적용
+            </button>
+          </>
+        )}
       </div>
 
       <PositionFilter
@@ -260,12 +315,10 @@ const User: NextPage = () => {
         <UserRankHeader sortBy={sortBy} sortOrder={sortOrder} onSort={handleSort} />
         <div key={selectedPosition} className="space-y-3 mt-2">
           {(() => {
-            // 비로그인 상태
             if (!isLoggedIn) {
               return <TextCard text="로그인 후 이용해주세요" />;
             }
 
-            // 소속 클랜 없음
             if (guilds.length === 0) {
               return <TextCard text="소속된 클랜이 없습니다" />;
             }
@@ -299,7 +352,6 @@ const User: NextPage = () => {
                           winRate={user.winRate}
                         />
                       ))}
-                      {/* 무한 스크롤 트리거 */}
                       {hasMore && <div ref={sentinelRef} className="h-10" />}
                     </>
                   )}

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -88,7 +88,7 @@ class ApiService {
 
     // 에러 처리: 401 에러 시 로그아웃
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    this.addErrorInterceptor(async (error, requestOptions) => {
+    this.addErrorInterceptor(async (error) => {
       if (error && typeof error === "object" && "status" in error && error.status === 401) {
         // 토큰 만료 또는 인증 오류
         if (typeof window !== "undefined") {
@@ -213,12 +213,15 @@ class ApiService {
 
       // 응답 데이터 파싱
       let data: unknown;
-      const contentType = response.headers.get("content-type");
-
-      if (contentType && contentType.includes("application/json")) {
-        data = await response.json();
+      if (response.status === 204) {
+        data = null;
       } else {
-        data = await response.text();
+        const contentType = response.headers.get("content-type");
+        if (contentType && contentType.includes("application/json")) {
+          data = await response.json();
+        } else {
+          data = await response.text();
+        }
       }
 
       // 응답 인터셉터 적용

--- a/src/services/statistics.ts
+++ b/src/services/statistics.ts
@@ -3,20 +3,35 @@ import { UserStatisticsResponse, ChampionStatisticsResponse } from "@/data/types
 import api from "@/services/index";
 
 export type Position = "ALL" | "TOP" | "JUG" | "MID" | "ADC" | "SUP";
+export type DatePreset = "recent" | "season" | "range";
+
+const buildQuery = (params: Record<string, string | number | undefined>): string => {
+  const parts = Object.entries(params)
+    .filter(([, v]) => v !== undefined)
+    .map(([k, v]) => `${k}=${v}`);
+  return parts.length ? `?${parts.join("&")}` : "";
+};
 
 export const getUserStatistics = async (
   guildId: string,
   position: Position,
-  year?: number,
-  month?: number
+  datePreset?: DatePreset,
+  season?: string,
+  fromMonth?: number,
+  toMonth?: number
 ): Promise<ApiResponse<UserStatisticsResponse>> => {
   try {
-    const positionParam = position === "ALL" ? "" : `position=${position}&`;
-    const yearMonthParam = year && month ? `&year=${year}&month=${month}` : "";
+    const query = buildQuery({
+      position: position !== "ALL" ? position : undefined,
+      sortBy: "winRate",
+      limit: 100000,
+      datePreset,
+      season,
+      fromMonth,
+      toMonth,
+    });
 
-    return await api.get(
-      `/api/statistics/${guildId}/users?${positionParam}sortBy=winRate&limit=100000${yearMonthParam}`
-    );
+    return await api.get(`/api/statistics/${guildId}/users${query}`);
   } catch (error) {
     return {
       data: null,
@@ -29,15 +44,23 @@ export const getUserStatistics = async (
 export const getChampionStatistics = async (
   guildId: string,
   position: Position,
-  year?: number,
-  month?: number
+  datePreset?: DatePreset,
+  season?: string,
+  fromMonth?: number,
+  toMonth?: number
 ): Promise<ApiResponse<ChampionStatisticsResponse>> => {
   try {
-    const yearMonthParam = year && month ? `&year=${year}&month=${month}` : "";
+    const query = buildQuery({
+      position,
+      sortBy: "winRate",
+      limit: 100000,
+      datePreset,
+      season,
+      fromMonth,
+      toMonth,
+    });
 
-    return await api.get(
-      `/api/statistics/${guildId}/champions?position=${position}&sortBy=winRate&limit=100000${yearMonthParam}`
-    );
+    return await api.get(`/api/statistics/${guildId}/champions${query}`);
   } catch (error) {
     return {
       data: null,


### PR DESCRIPTION
## 변경 사항
- 통계 페이지의 검색 모드 수정 (기존 : 최근, 월별검색 -> 변경 : 최근, 시즌, 기간 검색)
<img width="551" height="194" alt="image" src="https://github.com/user-attachments/assets/42d80a37-fbfe-4725-bab9-3a936b613726" />
<img width="589" height="199" alt="image" src="https://github.com/user-attachments/assets/43a2b57c-1c53-4773-8266-de81c24b4c7f" />
<img width="638" height="182" alt="image" src="https://github.com/user-attachments/assets/fb550194-0b38-4582-912a-c52776f550fa" />

- 챔피언 분석 페이지에 판 수, 승률 순 정렬 기능 추가
<img width="1112" height="674" alt="image" src="https://github.com/user-attachments/assets/3092aca2-2dc5-4a3e-9249-b18d4666d1ed" />

- 204 No Content에서 발생하는 버그 수정