### PR TITLE
TRC-234 프론트 디자인 개선 — 통계·매치 상세·H2H UI 정비 및 애니메이션

### DIFF
--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -16,12 +16,12 @@ const NavBar = () => {
       {navList.map(({ href, label, href2 }) => (
         <Link key={href2 || href} href={href2 || href}>
           <span
-            className={`cursor-pointer text-sm font-medium pb-1 whitespace-nowrap px-3 ${
+            className={`cursor-pointer text-sm pb-1 whitespace-nowrap px-3 ${
               router.pathname === href ||
               router.pathname === href2 ||
               (href === "/summoners" && router.pathname.startsWith("/summoners"))
-                ? "text-primary1 border-b-3 border-primary1"
-                : "text-primary2 border-b-3 border-transparent"
+                ? "text-primary1 font-bold border-b-3 border-blueText"
+                : "text-primary2 font-normal border-b-3 border-transparent"
             }`}
           >
             {label}

--- a/src/components/ui/CardWithTitle.tsx
+++ b/src/components/ui/CardWithTitle.tsx
@@ -10,7 +10,7 @@ interface Props {
 const CardWithTitle = ({ title, children, className }: Props) => {
   return (
     <Card className={className}>
-      <div className="text-primary1 p-2 pl-3 text-lg sm:text-xl md:text-2xl font-medium items-center">
+      <div className="text-primary1 p-2 pl-3 text-lg sm:text-xl md:text-2xl font-bold items-center">
         {title}
       </div>
       <hr className="border-t-2 border-border2" />

--- a/src/components/ui/TextCard.tsx
+++ b/src/components/ui/TextCard.tsx
@@ -7,11 +7,24 @@ interface Props {
 const TextCard = ({ text }: Props) => {
   return (
     <main className="mt-14 flex flex-col gap-3 md:min-w-[1080px]">
-      <div className="flex flex-col text-white">
-        <Card className="w-full p-4 text-center">
-          <p>{text}</p>
-        </Card>
-      </div>
+      <Card className="w-full">
+        <div className="flex flex-col items-center justify-center gap-3 px-4 py-7 text-center">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="#4A4F57"
+            strokeWidth={1.75}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="w-10 h-10"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="9" />
+            <path d="M12 8h.01M11 12h1v4h1" />
+          </svg>
+          <p className="text-sm text-primary1">{text}</p>
+        </div>
+      </Card>
     </main>
   );
 };

--- a/src/features/h2h/H2HChampMatchups.tsx
+++ b/src/features/h2h/H2HChampMatchups.tsx
@@ -376,7 +376,7 @@ const H2HChampMatchups = ({ matchups, topLanePair }: Props) => {
             return (
               <div
                 key={`${g.champ}|${g.lane}`}
-                className={isNew ? "animate-fadeUp" : undefined}
+                className={isNew ? "motion-safe:animate-fadeUp" : undefined}
                 style={isNew ? { animationDelay: `${(i - prevCount) * 60}ms` } : undefined}
               >
                 <ChampGroup group={g} koName={koName} defaultOpen={false} />

--- a/src/features/h2h/H2HChampMatchups.tsx
+++ b/src/features/h2h/H2HChampMatchups.tsx
@@ -75,7 +75,25 @@ const MatchupChildRow = ({ matchup, koName }: ChildRowProps) => {
       >
         <div
           className="bg-blueText"
-          style={{ height: "100%", width: `${winPct}%`, opacity: 0.55 }}
+          style={{
+            position: "absolute",
+            left: 0,
+            top: 0,
+            bottom: 0,
+            width: `${winPct}%`,
+            opacity: 0.55,
+          }}
+        />
+        <div
+          className="bg-redText"
+          style={{
+            position: "absolute",
+            right: 0,
+            top: 0,
+            bottom: 0,
+            width: `${100 - winPct}%`,
+            opacity: 0.5,
+          }}
         />
         <span
           className="text-primary2"
@@ -169,7 +187,25 @@ const ChampGroup = ({ group, koName, defaultOpen }: GroupProps) => {
         >
           <div
             className="bg-blueText"
-            style={{ height: "100%", width: `${winPct}%`, opacity: 0.6 }}
+            style={{
+              position: "absolute",
+              left: 0,
+              top: 0,
+              bottom: 0,
+              width: `${winPct}%`,
+              opacity: 0.6,
+            }}
+          />
+          <div
+            className="bg-redText"
+            style={{
+              position: "absolute",
+              right: 0,
+              top: 0,
+              bottom: 0,
+              width: `${100 - winPct}%`,
+              opacity: 0.55,
+            }}
           />
           <span
             className="text-white"
@@ -296,6 +332,7 @@ const H2HChampMatchups = ({ matchups, topLanePair }: Props) => {
   return (
     <SectionCard
       title="라인 · 챔피언 매치업"
+      stackOnMobile
       rightSlot={
         <div className="flex flex-wrap items-center justify-end gap-1.5">
           <LaneTabs value={lane} onChange={setLane} share={laneShare} />

--- a/src/features/h2h/H2HChampMatchups.tsx
+++ b/src/features/h2h/H2HChampMatchups.tsx
@@ -63,14 +63,23 @@ const MatchupChildRow = ({ matchup, koName }: ChildRowProps) => {
           {koName(matchup.oppoChamp)}
         </div>
       </div>
-      <div style={{ width: 64, textAlign: "center", fontSize: 12, fontFeatureSettings: '"tnum"' }}>
+      <div
+        className="shrink-0"
+        style={{
+          width: 64,
+          textAlign: "center",
+          fontSize: 12,
+          whiteSpace: "nowrap",
+          fontFeatureSettings: '"tnum"',
+        }}
+      >
         <b className="text-blueText">{matchup.wins}</b>
         <span className="text-primary2">승 </span>
         <b className="text-redText">{matchup.count - matchup.wins}</b>
         <span className="text-primary2">패</span>
       </div>
       <div
-        className="bg-rankBg3 shrink-0"
+        className="bg-rankBg3 hidden shrink-0 sm:block"
         style={{ position: "relative", width: 84, height: 14, borderRadius: 3, overflow: "hidden" }}
       >
         <div
@@ -111,7 +120,7 @@ const MatchupChildRow = ({ matchup, koName }: ChildRowProps) => {
           {matchup.count}판
         </span>
       </div>
-      <div style={{ width: 54, textAlign: "center" }}>
+      <div className="shrink-0" style={{ width: 54, textAlign: "center", whiteSpace: "nowrap" }}>
         <div className="text-primary1" style={{ fontSize: 12, fontFeatureSettings: '"tnum"' }}>
           {matchup.myKda}
         </div>
@@ -119,7 +128,7 @@ const MatchupChildRow = ({ matchup, koName }: ChildRowProps) => {
           내 KDA
         </div>
       </div>
-      <div style={{ width: 44, textAlign: "right" }}>
+      <div className="shrink-0" style={{ width: 44, textAlign: "right" }}>
         <div
           style={{
             fontSize: 14,

--- a/src/features/h2h/H2HChampMatchups.tsx
+++ b/src/features/h2h/H2HChampMatchups.tsx
@@ -267,14 +267,23 @@ const ChampGroup = ({ group, koName, defaultOpen }: GroupProps) => {
           <path d="M19 9l-7 7-7-7" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
       </button>
-      {open && (
-        <div style={{ background: "rgba(0,0,0,0.25)" }}>
-          {children.map((m, i) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <MatchupChildRow key={i} matchup={m} koName={koName} />
-          ))}
+      {/* grid-rows 0fr→1fr 트랜지션으로 부드럽게 펼침 */}
+      <div
+        className={`grid transition-[grid-template-rows,opacity] duration-300 ease-out ${
+          open ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
+        }`}
+      >
+        <div className="min-h-0 overflow-hidden">
+          {open && (
+            <div style={{ background: "rgba(0,0,0,0.25)" }}>
+              {children.map((m, i) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <MatchupChildRow key={i} matchup={m} koName={koName} />
+              ))}
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </div>
   );
 };

--- a/src/features/h2h/H2HChampMatchups.tsx
+++ b/src/features/h2h/H2HChampMatchups.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { H2HMatchup, LanePosition } from "@/data/types/h2h";
 import colors from "@/styles/colors";
 import useChampionKoNames from "@/hooks/useChampionKoNames";
@@ -347,6 +347,13 @@ const H2HChampMatchups = ({ matchups, topLanePair }: Props) => {
   const shown = groups.slice(0, visible);
   const remaining = groups.length - shown.length;
 
+  // 더보기로 새로 붙은 그룹만 순차 등장 (탭/필터 변경 시엔 개수가 줄어 애니메이션 없음)
+  const prevCountRef = useRef(shown.length);
+  const prevCount = prevCountRef.current;
+  useEffect(() => {
+    prevCountRef.current = shown.length;
+  }, [shown.length]);
+
   return (
     <SectionCard
       title="라인 · 챔피언 매치업"
@@ -364,14 +371,18 @@ const H2HChampMatchups = ({ matchups, topLanePair }: Props) => {
           <H2HTopLanePairCard label="가장 많이 맞붙은 라인" {...topLanePair} separator="vs" />
         )}
         {groups.length > 0 ? (
-          shown.map((g) => (
-            <ChampGroup
-              key={`${g.champ}|${g.lane}`}
-              group={g}
-              koName={koName}
-              defaultOpen={false}
-            />
-          ))
+          shown.map((g, i) => {
+            const isNew = i >= prevCount;
+            return (
+              <div
+                key={`${g.champ}|${g.lane}`}
+                className={isNew ? "animate-fadeUp" : undefined}
+                style={isNew ? { animationDelay: `${(i - prevCount) * 60}ms` } : undefined}
+              >
+                <ChampGroup group={g} koName={koName} defaultOpen={false} />
+              </div>
+            );
+          })
         ) : (
           <div className="text-primary2" style={{ padding: 24, textAlign: "center", fontSize: 13 }}>
             해당 라인 매치업이 없어요

--- a/src/features/h2h/H2HChampMatchups.tsx
+++ b/src/features/h2h/H2HChampMatchups.tsx
@@ -267,7 +267,6 @@ const ChampGroup = ({ group, koName, defaultOpen }: GroupProps) => {
           <path d="M19 9l-7 7-7-7" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
       </button>
-      {/* grid-rows 0fr→1fr 트랜지션으로 부드럽게 펼침 */}
       <div
         className={`grid transition-[grid-template-rows,opacity] duration-300 ease-out ${
           open ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
@@ -347,7 +346,6 @@ const H2HChampMatchups = ({ matchups, topLanePair }: Props) => {
   const shown = groups.slice(0, visible);
   const remaining = groups.length - shown.length;
 
-  // 더보기로 새로 붙은 그룹만 순차 등장 (탭/필터 변경 시엔 개수가 줄어 애니메이션 없음)
   const prevCountRef = useRef(shown.length);
   const prevCount = prevCountRef.current;
   useEffect(() => {

--- a/src/features/h2h/H2HDuoCombos.tsx
+++ b/src/features/h2h/H2HDuoCombos.tsx
@@ -208,14 +208,23 @@ const DuoGroupCard = ({ group, koName, defaultOpen }: GroupProps) => {
           <path d="M19 9l-7 7-7-7" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
       </button>
-      {open && (
-        <div style={{ background: "rgba(0,0,0,0.25)" }}>
-          {children.map((c, i) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <DuoChildRow key={i} combo={c} koName={koName} />
-          ))}
+      {/* grid-rows 0fr→1fr 트랜지션으로 부드럽게 펼침 */}
+      <div
+        className={`grid transition-[grid-template-rows,opacity] duration-300 ease-out ${
+          open ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
+        }`}
+      >
+        <div className="min-h-0 overflow-hidden">
+          {open && (
+            <div style={{ background: "rgba(0,0,0,0.25)" }}>
+              {children.map((c, i) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <DuoChildRow key={i} combo={c} koName={koName} />
+              ))}
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </div>
   );
 };

--- a/src/features/h2h/H2HDuoCombos.tsx
+++ b/src/features/h2h/H2HDuoCombos.tsx
@@ -308,7 +308,7 @@ const H2HDuoCombos = ({ combos, topLaneCombo }: Props) => {
             return (
               <div
                 key={`${g.champ}|${g.lane}`}
-                className={isNew ? "animate-fadeUp" : undefined}
+                className={isNew ? "motion-safe:animate-fadeUp" : undefined}
                 style={isNew ? { animationDelay: `${(i - prevCount) * 60}ms` } : undefined}
               >
                 <DuoGroupCard group={g} koName={koName} defaultOpen={false} />

--- a/src/features/h2h/H2HDuoCombos.tsx
+++ b/src/features/h2h/H2HDuoCombos.tsx
@@ -208,7 +208,6 @@ const DuoGroupCard = ({ group, koName, defaultOpen }: GroupProps) => {
           <path d="M19 9l-7 7-7-7" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
       </button>
-      {/* grid-rows 0fr→1fr 트랜지션으로 부드럽게 펼침 */}
       <div
         className={`grid transition-[grid-template-rows,opacity] duration-300 ease-out ${
           open ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
@@ -278,7 +277,6 @@ const H2HDuoCombos = ({ combos, topLaneCombo }: Props) => {
   const shown = groups.slice(0, visible);
   const remaining = groups.length - shown.length;
 
-  // 더보기로 새로 붙은 그룹만 순차 등장 (라인 탭 변경 시엔 개수가 줄어 애니메이션 없음)
   const prevCountRef = useRef(shown.length);
   const prevCount = prevCountRef.current;
   useEffect(() => {

--- a/src/features/h2h/H2HDuoCombos.tsx
+++ b/src/features/h2h/H2HDuoCombos.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { H2HDuoChamp, H2HLaneCombo, LanePosition } from "@/data/types/h2h";
 import colors from "@/styles/colors";
 import useChampionKoNames from "@/hooks/useChampionKoNames";
@@ -278,6 +278,13 @@ const H2HDuoCombos = ({ combos, topLaneCombo }: Props) => {
   const shown = groups.slice(0, visible);
   const remaining = groups.length - shown.length;
 
+  // 더보기로 새로 붙은 그룹만 순차 등장 (라인 탭 변경 시엔 개수가 줄어 애니메이션 없음)
+  const prevCountRef = useRef(shown.length);
+  const prevCount = prevCountRef.current;
+  useEffect(() => {
+    prevCountRef.current = shown.length;
+  }, [shown.length]);
+
   return (
     <SectionCard
       title="자주 가는 듀오 픽"
@@ -296,14 +303,18 @@ const H2HDuoCombos = ({ combos, topLaneCombo }: Props) => {
           />
         )}
         {groups.length > 0 ? (
-          shown.map((g) => (
-            <DuoGroupCard
-              key={`${g.champ}|${g.lane}`}
-              group={g}
-              koName={koName}
-              defaultOpen={false}
-            />
-          ))
+          shown.map((g, i) => {
+            const isNew = i >= prevCount;
+            return (
+              <div
+                key={`${g.champ}|${g.lane}`}
+                className={isNew ? "animate-fadeUp" : undefined}
+                style={isNew ? { animationDelay: `${(i - prevCount) * 60}ms` } : undefined}
+              >
+                <DuoGroupCard group={g} koName={koName} defaultOpen={false} />
+              </div>
+            );
+          })
         ) : (
           <div className="text-primary2" style={{ padding: 24, textAlign: "center", fontSize: 13 }}>
             해당 라인 듀오가 없어요

--- a/src/features/h2h/H2HRecentList.tsx
+++ b/src/features/h2h/H2HRecentList.tsx
@@ -218,7 +218,7 @@ const H2HRecentRow = ({ row, mode, open, onToggle }: RowProps) => {
   const isWin = row.myResult === "W";
   const accentText = isWin ? colors.blueText : colors.redText;
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+    <div style={{ display: "flex", flexDirection: "column" }}>
       <div
         className="bg-darkBg1 border border-border2 flex items-center gap-2 rounded px-3 py-2.5 sm:grid sm:grid-cols-[8px_80px_50px_auto_1fr_auto_auto] sm:gap-3 sm:px-3.5"
         style={{ borderLeft: `3px solid ${accentText}` }}
@@ -289,7 +289,18 @@ const H2HRecentRow = ({ row, mode, open, onToggle }: RowProps) => {
           {formatPlayedDate(row.playedDate)}
         </span>
       </div>
-      {open && !noDetail && <H2HRecentDetail row={row} />}
+      {/* grid-rows 0fr→1fr 트랜지션으로 부드럽게 펼침 (기존 gap:4는 pt-1로 대체) */}
+      {!noDetail && (
+        <div
+          className={`grid transition-[grid-template-rows,opacity] duration-300 ease-out ${
+            open ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
+          }`}
+        >
+          <div className="min-h-0 overflow-hidden">
+            <div className="pt-1">{open && <H2HRecentDetail row={row} />}</div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/features/h2h/H2HRecentList.tsx
+++ b/src/features/h2h/H2HRecentList.tsx
@@ -351,7 +351,7 @@ const H2HRecentList = ({ rows, mode, sameLaneOnly, onToggleSameLane }: Props) =>
             return (
               <div
                 key={r.matchId}
-                className={isNew ? "animate-fadeUp" : undefined}
+                className={isNew ? "motion-safe:animate-fadeUp" : undefined}
                 style={isNew ? { animationDelay: `${(i - prevCount) * 60}ms` } : undefined}
               >
                 <H2HRecentRow

--- a/src/features/h2h/H2HRecentList.tsx
+++ b/src/features/h2h/H2HRecentList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { H2HRecent, H2HRecentDetailMetrics, H2HRelation } from "@/data/types/h2h";
 import colors from "@/styles/colors";
 import { POSITION_LABELS, formatAgo, formatGameLen, formatPlayedDate } from "./h2hHelpers";
@@ -327,6 +327,13 @@ const H2HRecentList = ({ rows, mode, sameLaneOnly, onToggleSameLane }: Props) =>
   const shown = filtered.slice(0, visible);
   const remaining = filtered.length - shown.length;
 
+  // 더보기로 새로 붙은 항목만 순차 등장 (필터/모드 변경 시엔 개수가 줄어 애니메이션 없음)
+  const prevCountRef = useRef(shown.length);
+  const prevCount = prevCountRef.current;
+  useEffect(() => {
+    prevCountRef.current = shown.length;
+  }, [shown.length]);
+
   return (
     <SectionCard
       title={mode === "with" ? "최근 함께한 게임" : "최근 맞대결"}
@@ -339,15 +346,23 @@ const H2HRecentList = ({ rows, mode, sameLaneOnly, onToggleSameLane }: Props) =>
     >
       <div style={{ padding: 12, display: "flex", flexDirection: "column", gap: 6 }}>
         {filtered.length > 0 ? (
-          shown.map((r, i) => (
-            <H2HRecentRow
-              key={r.matchId}
-              row={r}
-              mode={mode}
-              open={openIdx === i}
-              onToggle={() => setOpenIdx(openIdx === i ? null : i)}
-            />
-          ))
+          shown.map((r, i) => {
+            const isNew = i >= prevCount;
+            return (
+              <div
+                key={r.matchId}
+                className={isNew ? "animate-fadeUp" : undefined}
+                style={isNew ? { animationDelay: `${(i - prevCount) * 60}ms` } : undefined}
+              >
+                <H2HRecentRow
+                  row={r}
+                  mode={mode}
+                  open={openIdx === i}
+                  onToggle={() => setOpenIdx(openIdx === i ? null : i)}
+                />
+              </div>
+            );
+          })
         ) : (
           <div className="text-primary2" style={{ padding: 24, textAlign: "center", fontSize: 13 }}>
             최근 기록이 없어요

--- a/src/features/h2h/H2HRecentList.tsx
+++ b/src/features/h2h/H2HRecentList.tsx
@@ -289,7 +289,6 @@ const H2HRecentRow = ({ row, mode, open, onToggle }: RowProps) => {
           {formatPlayedDate(row.playedDate)}
         </span>
       </div>
-      {/* grid-rows 0fr→1fr 트랜지션으로 부드럽게 펼침 (기존 gap:4는 pt-1로 대체) */}
       {!noDetail && (
         <div
           className={`grid transition-[grid-template-rows,opacity] duration-300 ease-out ${
@@ -327,7 +326,6 @@ const H2HRecentList = ({ rows, mode, sameLaneOnly, onToggleSameLane }: Props) =>
   const shown = filtered.slice(0, visible);
   const remaining = filtered.length - shown.length;
 
-  // 더보기로 새로 붙은 항목만 순차 등장 (필터/모드 변경 시엔 개수가 줄어 애니메이션 없음)
   const prevCountRef = useRef(shown.length);
   const prevCount = prevCountRef.current;
   useEffect(() => {

--- a/src/features/h2h/H2HRivalryTimeline.tsx
+++ b/src/features/h2h/H2HRivalryTimeline.tsx
@@ -120,7 +120,8 @@ const H2HRivalryTimeline = ({ streak, seasonBreaks = [] }: Props) => {
         pointerEvents: "none",
         opacity: show ? 1 : 0,
         transition: "opacity 0.2s ease",
-        background: `linear-gradient(to ${side}, ${colors.darkBg2} 30%, ${colors.darkBg2}00 100%)`,
+        // 가장자리(바깥쪽)가 불투명하고 안쪽으로 갈수록 투명해지도록 중앙 방향으로 페이드.
+        background: `linear-gradient(to ${side === "left" ? "right" : "left"}, ${colors.darkBg2} 30%, ${colors.darkBg2}00 100%)`,
         display: "flex",
         alignItems: "center",
         justifyContent: side === "left" ? "flex-start" : "flex-end",

--- a/src/features/h2h/H2HRivalryTimeline.tsx
+++ b/src/features/h2h/H2HRivalryTimeline.tsx
@@ -17,9 +17,33 @@ interface Props {
 
 // 데스크톱은 넓고 낮게, 모바일은 좁고 높게 — viewBox 비율을 바꿔
 // 100% 폭으로 줄어도 높이가 충분히 확보되어 가독성을 유지한다.
+// minGap: 점 사이 최소 간격(px). 맞대결이 많아 이 간격을 확보하지 못하면
+// 차트 폭을 늘리고 가로 스크롤로 전환해 점/라벨이 겹치지 않게 한다.
 const DIMS = {
-  desktop: { w: 1040, h: 170, padL: 24, padR: 76, padT: 18, padB: 26, fz: 10, fzCur: 13, dotR: 4 },
-  mobile: { w: 360, h: 240, padL: 16, padR: 52, padT: 18, padB: 26, fz: 12, fzCur: 15, dotR: 4.5 },
+  desktop: {
+    w: 1040,
+    h: 170,
+    padL: 24,
+    padR: 76,
+    padT: 18,
+    padB: 26,
+    fz: 10,
+    fzCur: 13,
+    dotR: 4,
+    minGap: 18,
+  },
+  mobile: {
+    w: 360,
+    h: 240,
+    padL: 16,
+    padR: 52,
+    padT: 18,
+    padB: 26,
+    fz: 12,
+    fzCur: 15,
+    dotR: 4.5,
+    minGap: 24,
+  },
 };
 
 const H2HRivalryTimeline = ({ streak, seasonBreaks = [] }: Props) => {
@@ -33,10 +57,26 @@ const H2HRivalryTimeline = ({ streak, seasonBreaks = [] }: Props) => {
     return () => mq.removeEventListener("change", update);
   }, []);
 
-  const { w, h, padL, padR, padT, padB, fz, fzCur, dotR } = isMobile ? DIMS.mobile : DIMS.desktop;
+  const {
+    w: baseW,
+    h,
+    padL,
+    padR,
+    padT,
+    padB,
+    fz,
+    fzCur,
+    dotR,
+    minGap,
+  } = isMobile ? DIMS.mobile : DIMS.desktop;
 
   const pts = [0];
   streak.forEach((s) => pts.push(pts[pts.length - 1] + (s === "W" ? 1 : -1)));
+
+  // 점 사이 최소 간격을 확보할 만큼 폭을 넓힌다. 기본 폭을 넘으면 가로 스크롤.
+  const neededW = padL + padR + (pts.length - 1) * minGap;
+  const w = Math.max(baseW, neededW);
+  const scrolls = w > baseW;
 
   const maxAbs = Math.max(2, ...pts.map((v) => Math.abs(v)));
   const x = (i: number) => padL + (i / (pts.length - 1 || 1)) * (w - padL - padR);
@@ -50,7 +90,7 @@ const H2HRivalryTimeline = ({ streak, seasonBreaks = [] }: Props) => {
   return (
     <SectionCard
       title="라이벌 히스토리"
-      subtitle="맞대결 누적 우위 (내 승 − 내 패) · 좌→우 시간순"
+      subtitle={`맞대결 누적 우위 (내 승 − 내 패) · 좌→우 시간순${scrolls ? " · 좌우 스크롤 ↔" : ""}`}
       rightSlot={
         <span
           className="bg-rankBg2 border border-border2"
@@ -68,8 +108,21 @@ const H2HRivalryTimeline = ({ streak, seasonBreaks = [] }: Props) => {
         </span>
       }
     >
-      <div style={{ padding: "8px 16px 14px" }}>
-        <svg viewBox={`0 0 ${w} ${h}`} style={{ width: "100%", height: "auto", display: "block" }}>
+      <div
+        style={{
+          padding: "8px 16px 14px",
+          overflowX: scrolls ? "auto" : "visible",
+          WebkitOverflowScrolling: "touch",
+        }}
+      >
+        <svg
+          viewBox={`0 0 ${w} ${h}`}
+          style={{
+            width: scrolls ? `${w}px` : "100%",
+            height: "auto",
+            display: "block",
+          }}
+        >
           {/* zero baseline */}
           <line
             className="stroke-border1"

--- a/src/features/h2h/H2HRivalryTimeline.tsx
+++ b/src/features/h2h/H2HRivalryTimeline.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { H2HResult, H2HSeasonBreak } from "@/data/types/h2h";
 import colors from "@/styles/colors";
 import { diffColor } from "./h2hHelpers";
@@ -48,6 +48,9 @@ const DIMS = {
 
 const H2HRivalryTimeline = ({ streak, seasonBreaks = [] }: Props) => {
   const [isMobile, setIsMobile] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
 
   useEffect(() => {
     const mq = window.matchMedia("(max-width: 640px)");
@@ -87,6 +90,55 @@ const H2HRivalryTimeline = ({ streak, seasonBreaks = [] }: Props) => {
   const cur = pts[pts.length - 1];
   const curColor = diffColor(cur, colors.blueText, colors.redText, colors.primary2);
 
+  // 스크롤 위치에 따라 양쪽 페이드(더 볼 내용 있음) 표시 여부를 갱신한다.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return undefined;
+    const update = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      setCanScrollLeft(el.scrollLeft > 1);
+      setCanScrollRight(el.scrollLeft < max - 1);
+    };
+    update();
+    el.addEventListener("scroll", update, { passive: true });
+    window.addEventListener("resize", update);
+    return () => {
+      el.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+    };
+  }, [scrolls, w]);
+
+  const edgeFade = (side: "left" | "right", show: boolean) => (
+    <div
+      aria-hidden
+      style={{
+        position: "absolute",
+        top: 0,
+        bottom: 0,
+        [side]: 0,
+        width: 44,
+        pointerEvents: "none",
+        opacity: show ? 1 : 0,
+        transition: "opacity 0.2s ease",
+        background: `linear-gradient(to ${side}, ${colors.darkBg2} 30%, ${colors.darkBg2}00 100%)`,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: side === "left" ? "flex-start" : "flex-end",
+      }}
+    >
+      <span
+        className="text-primary2"
+        style={{
+          fontSize: 16,
+          fontWeight: 700,
+          padding: side === "left" ? "0 0 0 6px" : "0 6px 0 0",
+        }}
+      >
+        {side === "left" ? "‹" : "›"}
+      </span>
+    </div>
+  );
+
   return (
     <SectionCard
       title="라이벌 히스토리"
@@ -108,86 +160,91 @@ const H2HRivalryTimeline = ({ streak, seasonBreaks = [] }: Props) => {
         </span>
       }
     >
-      <div
-        style={{
-          padding: "8px 16px 14px",
-          overflowX: scrolls ? "auto" : "visible",
-          WebkitOverflowScrolling: "touch",
-        }}
-      >
-        <svg
-          viewBox={`0 0 ${w} ${h}`}
+      <div style={{ position: "relative" }}>
+        <div
+          ref={scrollRef}
           style={{
-            width: scrolls ? `${w}px` : "100%",
-            height: "auto",
-            display: "block",
+            padding: "8px 16px 14px",
+            overflowX: scrolls ? "auto" : "visible",
+            WebkitOverflowScrolling: "touch",
           }}
         >
-          {/* zero baseline */}
-          <line
-            className="stroke-border1"
-            x1={padL}
-            y1={y(0)}
-            x2={w - padR}
-            y2={y(0)}
-            strokeDasharray="4 4"
-          />
-          {/* zone labels */}
-          <text className="fill-blueText" x={padL} y={padT + 4} fontSize={fz} opacity={0.75}>
-            내 우위 ↑
-          </text>
-          <text className="fill-redText" x={padL} y={h - padB + 2} fontSize={fz} opacity={0.75}>
-            상대 우위 ↓
-          </text>
-          {/* season breaks */}
-          {seasonBreaks.map((b) => (
-            <g key={b.index}>
-              <line
-                className="stroke-border1"
-                x1={x(b.index)}
-                y1={padT - 6}
-                x2={x(b.index)}
-                y2={h - padB + 6}
-                strokeDasharray="2 3"
-              />
-              <text className="fill-primary2" x={x(b.index) + 5} y={padT + 2} fontSize={fz}>
-                {b.label}
-              </text>
-            </g>
-          ))}
-          {/* cumulative step line */}
-          <path className="stroke-primary2" d={linePath} fill="none" strokeWidth={1.5} />
-          {/* per-game dots */}
-          {pts.map((v, i) =>
-            i === 0 ? null : (
-              <circle
-                // eslint-disable-next-line react/no-array-index-key
-                key={i}
-                className="stroke-darkBg2"
-                cx={x(i)}
-                cy={y(v)}
-                r={dotR}
-                fill={streak[i - 1] === "W" ? colors.blueText : colors.redText}
-                strokeWidth={1.5}
-              >
-                <title>{`${i}번째 맞대결 — ${streak[i - 1] === "W" ? "승" : "패"} (누적 ${
-                  v > 0 ? `+${v}` : v
-                })`}</title>
-              </circle>
-            )
-          )}
-          {/* current value */}
-          <text
-            x={x(pts.length - 1) + 10}
-            y={y(cur) + 4}
-            fill={curColor}
-            fontSize={fzCur}
-            fontWeight={700}
-            style={{ fontFeatureSettings: '"tnum"' }}
+          <svg
+            viewBox={`0 0 ${w} ${h}`}
+            style={{
+              width: scrolls ? `${w}px` : "100%",
+              height: "auto",
+              display: "block",
+            }}
           >
-            {cur > 0 ? `+${cur}` : cur}
-          </text>
-        </svg>
+            {/* zero baseline */}
+            <line
+              className="stroke-border1"
+              x1={padL}
+              y1={y(0)}
+              x2={w - padR}
+              y2={y(0)}
+              strokeDasharray="4 4"
+            />
+            {/* zone labels */}
+            <text className="fill-blueText" x={padL} y={padT + 4} fontSize={fz} opacity={0.75}>
+              내 우위 ↑
+            </text>
+            <text className="fill-redText" x={padL} y={h - padB + 2} fontSize={fz} opacity={0.75}>
+              상대 우위 ↓
+            </text>
+            {/* season breaks */}
+            {seasonBreaks.map((b) => (
+              <g key={b.index}>
+                <line
+                  className="stroke-border1"
+                  x1={x(b.index)}
+                  y1={padT - 6}
+                  x2={x(b.index)}
+                  y2={h - padB + 6}
+                  strokeDasharray="2 3"
+                />
+                <text className="fill-primary2" x={x(b.index) + 5} y={padT + 2} fontSize={fz}>
+                  {b.label}
+                </text>
+              </g>
+            ))}
+            {/* cumulative step line */}
+            <path className="stroke-primary2" d={linePath} fill="none" strokeWidth={1.5} />
+            {/* per-game dots */}
+            {pts.map((v, i) =>
+              i === 0 ? null : (
+                <circle
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={i}
+                  className="stroke-darkBg2"
+                  cx={x(i)}
+                  cy={y(v)}
+                  r={dotR}
+                  fill={streak[i - 1] === "W" ? colors.blueText : colors.redText}
+                  strokeWidth={1.5}
+                >
+                  <title>{`${i}번째 맞대결 — ${streak[i - 1] === "W" ? "승" : "패"} (누적 ${
+                    v > 0 ? `+${v}` : v
+                  })`}</title>
+                </circle>
+              )
+            )}
+            {/* current value */}
+            <text
+              x={x(pts.length - 1) + 10}
+              y={y(cur) + 4}
+              fill={curColor}
+              fontSize={fzCur}
+              fontWeight={700}
+              style={{ fontFeatureSettings: '"tnum"' }}
+            >
+              {cur > 0 ? `+${cur}` : cur}
+            </text>
+          </svg>
+        </div>
+        {scrolls && edgeFade("left", canScrollLeft)}
+        {scrolls && edgeFade("right", canScrollRight)}
       </div>
     </SectionCard>
   );

--- a/src/features/h2h/SectionCard.tsx
+++ b/src/features/h2h/SectionCard.tsx
@@ -4,10 +4,13 @@ interface Props {
   title: string;
   subtitle?: string;
   rightSlot?: React.ReactNode;
+  // 모바일(<640px)에서 제목과 rightSlot을 2행으로 분리한다.
+  // 필터가 많아 한 행에 넣으면 제목이 여러 줄로 접히는 카드에서 사용.
+  stackOnMobile?: boolean;
   children: React.ReactNode;
 }
 
-const SectionCard = ({ title, subtitle, rightSlot, children }: Props) => (
+const SectionCard = ({ title, subtitle, rightSlot, stackOnMobile, children }: Props) => (
   <div
     className="bg-darkBg2 border border-border2"
     style={{
@@ -16,14 +19,11 @@ const SectionCard = ({ title, subtitle, rightSlot, children }: Props) => (
     }}
   >
     <div
-      className="border-b border-border2"
-      style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "space-between",
-        gap: 12,
-        padding: "12px 16px",
-      }}
+      className={`border-b border-border2 flex gap-3 px-4 py-3 ${
+        stackOnMobile
+          ? "flex-col items-stretch sm:flex-row sm:items-center sm:justify-between"
+          : "items-center justify-between"
+      }`}
     >
       <div>
         <div className="text-primary1" style={{ fontSize: 14, fontWeight: 600 }}>

--- a/src/features/matchHistory/MatchDetail.tsx
+++ b/src/features/matchHistory/MatchDetail.tsx
@@ -88,18 +88,22 @@ const MatchDetail = ({ participantData }: Props) => {
       </div>
 
       {/* 모바일 · 태블릿 */}
-      <div className="flex flex-col md:hidden min-w-0">
+      <div className="flex flex-col gap-2 md:hidden min-w-0">
         <MatchDetailTableMobile
           players={winParticipants}
           isWin
           maxDamage={maxDamage}
           maxDamageTaken={maxDamageTaken}
+          teamLabel={winLabel}
+          teamSummary={winSummary}
         />
         <MatchDetailTableMobile
           players={loseParticipants}
           isWin={false}
           maxDamage={maxDamage}
           maxDamageTaken={maxDamageTaken}
+          teamLabel={loseLabel}
+          teamSummary={loseSummary}
         />
       </div>
     </>

--- a/src/features/matchHistory/MatchDetail.tsx
+++ b/src/features/matchHistory/MatchDetail.tsx
@@ -67,8 +67,8 @@ const MatchDetail = ({ participantData }: Props) => {
 
   return (
     <>
-      {/* PC */}
-      <div className="hidden sm:flex sm:flex-col gap-2">
+      {/* PC (태블릿 이하는 유동형 모바일 표) */}
+      <div className="hidden md:flex md:flex-col gap-2">
         <MatchDetailTable
           players={winParticipants}
           isWin
@@ -87,8 +87,8 @@ const MatchDetail = ({ participantData }: Props) => {
         />
       </div>
 
-      {/* 모바일 */}
-      <div className="flex flex-col sm:hidden">
+      {/* 모바일 · 태블릿 */}
+      <div className="flex flex-col md:hidden">
         <MatchDetailTableMobile
           players={winParticipants}
           isWin

--- a/src/features/matchHistory/MatchDetail.tsx
+++ b/src/features/matchHistory/MatchDetail.tsx
@@ -68,7 +68,7 @@ const MatchDetail = ({ participantData }: Props) => {
   return (
     <>
       {/* PC (태블릿 이하는 유동형 모바일 표) */}
-      <div className="hidden md:flex md:flex-col gap-2">
+      <div className="hidden md:flex md:flex-col gap-2 min-w-0">
         <MatchDetailTable
           players={winParticipants}
           isWin
@@ -88,7 +88,7 @@ const MatchDetail = ({ participantData }: Props) => {
       </div>
 
       {/* 모바일 · 태블릿 */}
-      <div className="flex flex-col md:hidden">
+      <div className="flex flex-col md:hidden min-w-0">
         <MatchDetailTableMobile
           players={winParticipants}
           isWin

--- a/src/features/matchHistory/MatchDetail.tsx
+++ b/src/features/matchHistory/MatchDetail.tsx
@@ -13,6 +13,7 @@ const MatchDetail = ({ participantData }: Props) => {
       tag: participant.riotNameTag,
       champName: participant.champName,
       champNameEng: participant.champNameEng,
+      level: participant.level,
       kda: `${participant.kill} / ${participant.death} / ${participant.assist}`,
       kdaRate: (participant.kill + participant.assist) / participant.death,
       damage: participant.totalDamageChampions,
@@ -40,33 +41,49 @@ const MatchDetail = ({ participantData }: Props) => {
     }));
   };
 
-  const winParticipants = mapParticipantData(
-    participantData.filter((participant) => participant.gameResult === "승")
-  );
+  const rawWin = participantData.filter((participant) => participant.gameResult === "승");
+  const rawLose = participantData.filter((participant) => participant.gameResult === "패");
 
-  const loseParticipants = mapParticipantData(
-    participantData.filter((participant) => participant.gameResult === "패")
-  );
+  const winParticipants = mapParticipantData(rawWin);
+  const loseParticipants = mapParticipantData(rawLose);
 
   const allMapped = [...winParticipants, ...loseParticipants];
   const maxDamage = Math.max(...allMapped.map((p) => p.damage), 1);
   const maxDamageTaken = Math.max(...allMapped.map((p) => p.damageTaken), 1);
 
+  // 팀 합계(합계 KDA + 딜 total) 및 팀 라벨
+  const teamSummary = (participants: GameParticipant[]) => ({
+    kills: participants.reduce((sum, p) => sum + p.kill, 0),
+    deaths: participants.reduce((sum, p) => sum + p.death, 0),
+    assists: participants.reduce((sum, p) => sum + p.assist, 0),
+    damage: participants.reduce((sum, p) => sum + p.totalDamageChampions, 0),
+  });
+  const teamLabel = (color?: "red" | "blue") => (color === "red" ? "레드 팀" : "블루 팀");
+
+  const winSummary = teamSummary(rawWin);
+  const loseSummary = teamSummary(rawLose);
+  const winLabel = teamLabel(rawWin[0]?.gameTeam);
+  const loseLabel = teamLabel(rawLose[0]?.gameTeam);
+
   return (
     <>
       {/* PC */}
-      <div className="hidden sm:flex sm:flex-col">
+      <div className="hidden sm:flex sm:flex-col gap-2">
         <MatchDetailTable
           players={winParticipants}
           isWin
           maxDamage={maxDamage}
           maxDamageTaken={maxDamageTaken}
+          teamLabel={winLabel}
+          teamSummary={winSummary}
         />
         <MatchDetailTable
           players={loseParticipants}
           isWin={false}
           maxDamage={maxDamage}
           maxDamageTaken={maxDamageTaken}
+          teamLabel={loseLabel}
+          teamSummary={loseSummary}
         />
       </div>
 

--- a/src/features/matchHistory/MatchDetailTable.tsx
+++ b/src/features/matchHistory/MatchDetailTable.tsx
@@ -98,17 +98,17 @@ const MatchDetailTable = ({
 
       {/* 열 제목 */}
       <div
-        className="grid items-center gap-2 px-4 py-1.5 text-[11px] text-primary3"
+        className="grid items-center gap-2 px-4 py-1.5 text-[11px] text-primary3 text-center"
         style={{ gridTemplateColumns: GRID_COLUMNS }}
       >
         <div />
         <div>소환사</div>
         <div>빌드</div>
-        <div className="text-center">KDA</div>
-        <div className="text-center">관여</div>
+        <div>KDA</div>
+        <div>관여</div>
         <div>가한 피해</div>
         <div>받은 피해</div>
-        <div className="text-center">시야</div>
+        <div>시야</div>
       </div>
 
       {/* 플레이어 행 */}

--- a/src/features/matchHistory/MatchDetailTable.tsx
+++ b/src/features/matchHistory/MatchDetailTable.tsx
@@ -52,7 +52,7 @@ interface MatchDetailProps {
 // 챔피언 · 소환사 · 빌드 · KDA · 관여 · 가한피해 · 받은피해 · 시야
 // 소환사 열만 유동(1fr)으로 남는 공간을 흡수하고 나머지는 고정폭으로 좁게 잡아,
 // 최소 레이아웃 폭(min-w-[1080px])에서도 최근 전적 카드 안에 들어가도록 한다.
-const GRID_COLUMNS = "40px minmax(84px,1fr) 96px 78px 38px 88px 88px 50px";
+const GRID_COLUMNS = "40px minmax(76px,1fr) 112px 78px 54px 88px 88px 50px";
 
 const MatchDetailTable = ({
   players,
@@ -152,7 +152,6 @@ const MatchDetailTable = ({
               isCenter={false}
               className="text-[13px] text-primary1"
             />
-            <div className="text-[11px] text-primary3 truncate">{player.champName}</div>
           </div>
 
           {/* 3. 빌드 (스펠·룬·아이템) */}
@@ -162,33 +161,33 @@ const MatchDetailTable = ({
                 <SpellWithTooltip
                   spellKey={player.spells[0]}
                   spellName={player.spellNames[0]}
-                  width={17}
-                  height={17}
+                  width={20}
+                  height={20}
                   alt="스펠 1"
-                  className="w-[17px] h-[17px]"
+                  className="w-[20px] h-[20px]"
                 />
                 <SpellWithTooltip
                   spellKey={player.spells[1]}
                   spellName={player.spellNames[1]}
-                  width={17}
-                  height={17}
+                  width={20}
+                  height={20}
                   alt="스펠 2"
-                  className="w-[17px] h-[17px]"
+                  className="w-[20px] h-[20px]"
                 />
               </div>
               <div className="flex flex-col">
                 <RuneWithTooltip
                   iconPath={player.keystone}
                   runeName={player.keystoneName}
-                  width={17}
-                  height={17}
+                  width={20}
+                  height={20}
                   alt="룬 1"
                 />
                 <RuneWithTooltip
                   iconPath={player.perk}
                   runeName={player.perkName}
-                  width={17}
-                  height={17}
+                  width={20}
+                  height={20}
                   alt="룬 2"
                 />
               </div>
@@ -199,15 +198,15 @@ const MatchDetailTable = ({
                   <ItemWithTooltip
                     key={`slot-${slot}`}
                     itemId={player.items[slot]}
-                    width={17}
-                    height={17}
+                    width={20}
+                    height={20}
                     alt={`아이템 ${slot + 1}`}
-                    className="w-[17px] h-[17px] rounded-[3px]"
+                    className="w-[20px] h-[20px] rounded-[3px]"
                   />
                 ) : (
                   <div
                     key={`empty-slot-${slot}`}
-                    className="w-[17px] h-[17px] rounded-[3px]"
+                    className="w-[20px] h-[20px] rounded-[3px]"
                     style={{ backgroundColor: "#1C1F24" }}
                   />
                 )

--- a/src/features/matchHistory/MatchDetailTable.tsx
+++ b/src/features/matchHistory/MatchDetailTable.tsx
@@ -50,7 +50,8 @@ interface MatchDetailProps {
 }
 
 // 44 챔피언 · 소환사 · 빌드 · KDA · 관여 · 가한피해 · 받은피해 · 시야
-const GRID_COLUMNS = "44px minmax(80px,1fr) 128px 84px 44px 104px 104px 56px";
+// 소환사 열은 넓게(min 120px, 1fr로 확장), 빌드 열은 콘텐츠(≈95px)에 맞춰 좁게(100px)
+const GRID_COLUMNS = "44px minmax(120px,1fr) 100px 84px 44px 104px 104px 56px";
 
 const MatchDetailTable = ({
   players,

--- a/src/features/matchHistory/MatchDetailTable.tsx
+++ b/src/features/matchHistory/MatchDetailTable.tsx
@@ -49,9 +49,10 @@ interface MatchDetailProps {
   teamSummary: TeamSummary;
 }
 
-// 44 챔피언 · 소환사 · 빌드 · KDA · 관여 · 가한피해 · 받은피해 · 시야
-// 소환사 열은 넓게(min 120px, 1fr로 확장), 빌드 열은 콘텐츠(≈95px)에 맞춰 좁게(100px)
-const GRID_COLUMNS = "44px minmax(120px,1fr) 100px 84px 44px 104px 104px 56px";
+// 챔피언 · 소환사 · 빌드 · KDA · 관여 · 가한피해 · 받은피해 · 시야
+// 소환사 열만 유동(1fr)으로 남는 공간을 흡수하고 나머지는 고정폭으로 좁게 잡아,
+// 최소 레이아웃 폭(min-w-[1080px])에서도 최근 전적 카드 안에 들어가도록 한다.
+const GRID_COLUMNS = "40px minmax(84px,1fr) 96px 78px 38px 88px 88px 50px";
 
 const MatchDetailTable = ({
   players,
@@ -68,7 +69,7 @@ const MatchDetailTable = ({
   const pillBg = `rgba(${accentRgb},0.14)`;
 
   return (
-    <div className="bg-darkBg2 border border-cardBorder rounded-[10px] overflow-hidden text-base">
+    <div className="w-full min-w-0 bg-darkBg2 border border-cardBorder rounded-[10px] overflow-hidden text-base">
       {/* 팀 요약 헤더 */}
       <div
         className="flex items-center justify-between py-2 pr-4"
@@ -99,7 +100,7 @@ const MatchDetailTable = ({
 
       {/* 열 제목 */}
       <div
-        className="grid items-center gap-2 px-4 py-1.5 text-[11px] text-primary3 text-center"
+        className="grid items-center gap-1.5 px-3 py-1.5 text-[11px] text-primary3 text-center"
         style={{ gridTemplateColumns: GRID_COLUMNS }}
       >
         <div />
@@ -116,7 +117,7 @@ const MatchDetailTable = ({
       {players.map((player) => (
         <div
           key={`${player.name}-${player.tag}`}
-          className="grid items-center gap-2 px-4 py-[7px]"
+          className="grid items-center gap-1.5 px-3 py-[7px]"
           style={{
             gridTemplateColumns: GRID_COLUMNS,
             backgroundColor: rowTint,

--- a/src/features/matchHistory/MatchDetailTable.tsx
+++ b/src/features/matchHistory/MatchDetailTable.tsx
@@ -16,6 +16,7 @@ interface Player {
   tag: string;
   champName: string;
   champNameEng: string;
+  level: number;
   kda: string;
   kdaRate: number;
   damage: number;
@@ -32,35 +33,97 @@ interface Player {
   killParticipation: number;
 }
 
+interface TeamSummary {
+  kills: number;
+  deaths: number;
+  assists: number;
+  damage: number;
+}
+
 interface MatchDetailProps {
   players: Player[];
   isWin: boolean;
   maxDamage: number;
   maxDamageTaken: number;
+  teamLabel: string;
+  teamSummary: TeamSummary;
 }
 
-const MatchDetailTable = ({ players, isWin, maxDamage, maxDamageTaken }: MatchDetailProps) => {
-  return (
-    <div className={`${isWin ? "bg-blueLighten" : "bg-redLighten"} rounded-md text-base`}>
-      <div className="grid grid-cols-[0.7fr_100px_1.2fr_0.8fr_0.7fr_0.8fr_0.8fr_0.8fr] place-items-center text-center gap-y-1 py-[2px] whitespace-nowrap">
-        {/* 제목 행 */}
-        {isWin && (
-          <>
-            <div className="bg-border1 text-white font-bold w-full">챔피언</div>
-            <div className="bg-border1 text-white font-bold w-full">소환사명</div>
-            <div className="bg-border1 text-white font-bold w-full">빌드</div>
-            <div className="bg-border1 text-white font-bold w-full">KDA</div>
-            <div className="bg-border1 text-white font-bold w-full">킬관여율</div>
-            <div className="bg-border1 text-white font-bold w-full">준 피해량</div>
-            <div className="bg-border1 text-white font-bold w-full">받은 피해량</div>
-            <div className="bg-border1 text-white font-bold w-full">시야</div>
-          </>
-        )}
+// 44 챔피언 · 소환사 · 빌드 · KDA · 관여 · 가한피해 · 받은피해 · 시야
+const GRID_COLUMNS = "44px minmax(80px,1fr) 128px 84px 44px 104px 104px 56px";
 
-        {/* 데이터 행 */}
-        {players.map((player) => (
-          <React.Fragment key={`${player.name}-${player.tag}`}>
-            {/* 1. 챔피언 이미지 */}
+const MatchDetailTable = ({
+  players,
+  isWin,
+  maxDamage,
+  maxDamageTaken,
+  teamLabel,
+  teamSummary,
+}: MatchDetailProps) => {
+  const accent = isWin ? "#58A6FF" : "#F2789F";
+  const accentRgb = isWin ? "88,166,255" : "242,120,159";
+  const headerBg = isWin ? "#0E1A2B" : "#241019";
+  const rowTint = `rgba(${accentRgb},0.04)`;
+  const pillBg = `rgba(${accentRgb},0.14)`;
+
+  return (
+    <div className="bg-darkBg2 border border-cardBorder rounded-[10px] overflow-hidden text-base">
+      {/* 팀 요약 헤더 */}
+      <div
+        className="flex items-center justify-between py-2 pr-4"
+        style={{ backgroundColor: headerBg, borderLeft: `3px solid ${accent}` }}
+      >
+        <div className="flex items-center gap-2.5 pl-3">
+          <span
+            className="text-xs font-bold rounded px-2 py-0.5"
+            style={{ color: accent, backgroundColor: pillBg }}
+          >
+            {isWin ? "승리" : "패배"}
+          </span>
+          <span className="text-xs text-primary2">{teamLabel}</span>
+        </div>
+        <div className="flex items-center gap-4 text-xs tabular-nums">
+          <span className="text-primary2">
+            합계{" "}
+            <span className="text-primary1 font-bold">
+              {teamSummary.kills} / {teamSummary.deaths} / {teamSummary.assists}
+            </span>
+          </span>
+          <span className="text-primary2">
+            딜{" "}
+            <span className="text-primary1 font-bold">{teamSummary.damage.toLocaleString()}</span>
+          </span>
+        </div>
+      </div>
+
+      {/* 열 제목 */}
+      <div
+        className="grid items-center gap-2 px-4 py-1.5 text-[11px] text-primary3"
+        style={{ gridTemplateColumns: GRID_COLUMNS }}
+      >
+        <div />
+        <div>소환사</div>
+        <div>빌드</div>
+        <div className="text-center">KDA</div>
+        <div className="text-center">관여</div>
+        <div>가한 피해</div>
+        <div>받은 피해</div>
+        <div className="text-center">시야</div>
+      </div>
+
+      {/* 플레이어 행 */}
+      {players.map((player) => (
+        <div
+          key={`${player.name}-${player.tag}`}
+          className="grid items-center gap-2 px-4 py-[7px]"
+          style={{
+            gridTemplateColumns: GRID_COLUMNS,
+            backgroundColor: rowTint,
+            borderBottom: "1px solid #141619",
+          }}
+        >
+          {/* 1. 챔피언 + 레벨 배지 */}
+          <div className="relative w-9 h-9">
             <Tooltip content={player.champName} compact>
               <SpriteImage
                 spriteData={getChampionSprite(player.champNameEng)}
@@ -68,148 +131,174 @@ const MatchDetailTable = ({ players, isWin, maxDamage, maxDamageTaken }: MatchDe
                 height={36}
                 alt="챔피언"
                 fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/champion/${player.champNameEng}.png`}
-                className="w-[36px] h-[36px]"
+                className="w-9 h-9 rounded-lg"
               />
             </Tooltip>
+            <span
+              className="absolute -bottom-1 -right-1 text-[9px] font-bold leading-none text-primary1 rounded px-1 py-px border border-border1"
+              style={{ backgroundColor: "#0A0B0D" }}
+            >
+              {player.level}
+            </span>
+          </div>
 
-            {/* 2. 소환사명 */}
-            <PlayerNameButton name={player.name} tag={player.tag} isCenter={false} />
+          {/* 2. 소환사 */}
+          <div className="min-w-0">
+            <PlayerNameButton
+              name={player.name}
+              tag={player.tag}
+              isCenter={false}
+              className="text-[13px] text-primary1"
+            />
+            <div className="text-[11px] text-primary3 truncate">{player.champName}</div>
+          </div>
 
-            {/* 3. 빌드(룬, 스펠, 아이템) */}
-            <div className="flex gap-x-2">
-              <div className="flex">
-                <div className="flex flex-col gap-0">
-                  <SpellWithTooltip
-                    spellKey={player.spells[0]}
-                    spellName={player.spellNames[0]}
-                    width={18}
-                    height={18}
-                    alt="스펠 1"
-                    className="w-[18px] h-[18px]"
-                  />
-                  <SpellWithTooltip
-                    spellKey={player.spells[1]}
-                    spellName={player.spellNames[1]}
-                    width={18}
-                    height={18}
-                    alt="스펠 2"
-                    className="w-[18px] h-[18px]"
-                  />
-                </div>
-                <div className="flex flex-col gap-0">
-                  <RuneWithTooltip
-                    iconPath={player.keystone}
-                    runeName={player.keystoneName}
-                    width={18}
-                    height={18}
-                    alt="룬 1"
-                  />
-                  <RuneWithTooltip
-                    iconPath={player.perk}
-                    runeName={player.perkName}
-                    width={18}
-                    height={18}
-                    alt="룬 2"
-                  />
-                </div>
+          {/* 3. 빌드 (스펠·룬·아이템) */}
+          <div className="flex items-center gap-1.5">
+            <div className="flex">
+              <div className="flex flex-col">
+                <SpellWithTooltip
+                  spellKey={player.spells[0]}
+                  spellName={player.spellNames[0]}
+                  width={17}
+                  height={17}
+                  alt="스펠 1"
+                  className="w-[17px] h-[17px]"
+                />
+                <SpellWithTooltip
+                  spellKey={player.spells[1]}
+                  spellName={player.spellNames[1]}
+                  width={17}
+                  height={17}
+                  alt="스펠 2"
+                  className="w-[17px] h-[17px]"
+                />
               </div>
-              <div className="grid grid-cols-3 grid-rows-2 max-w-[96px] gap-[3px]">
-                {[0, 1, 2, 3, 4, 5].map((slot) =>
-                  player.items[slot] !== 0 ? (
-                    <ItemWithTooltip
-                      key={`slot-${slot}`}
-                      itemId={player.items[slot]}
-                      width={18}
-                      height={18}
-                      alt={`아이템 ${slot + 1}`}
-                      className="w-[18px] h-[18px]"
-                    />
-                  ) : (
-                    <div
-                      key={`empty-slot-${slot}`}
-                      className="w-[18px] h-[18px] rounded-[4px] bg-border1"
-                    />
-                  )
-                )}
-              </div>
-            </div>
-
-            {/* 4. KDA */}
-            <div className="flex flex-col">
-              <span className="text-sm">{player.kda}</span>
-              <span className={`text-xs font-semibold ${getKdaColor(player.kdaRate)}`}>
-                {player.kdaRate.toFixed(2)} KDA
-              </span>
-            </div>
-
-            {/* 5. 킬 관여율 */}
-            <div className="text-sm">{player.killParticipation}%</div>
-
-            {/* 6. 준 피해량 */}
-            <div className="flex flex-col w-full px-2 gap-y-0.5">
-              <div className="flex items-center gap-x-1 text-left">
-                <span className="text-xs md:text-sm tabular-nums">
-                  {player.damage.toLocaleString()}
-                </span>
-              </div>
-              <div className="h-1.5 w-full rounded-full overflow-hidden bg-black">
-                <div
-                  className="h-full rounded-full bg-blueText"
-                  style={{ width: `${(player.damage / maxDamage) * 100}%` }}
+              <div className="flex flex-col">
+                <RuneWithTooltip
+                  iconPath={player.keystone}
+                  runeName={player.keystoneName}
+                  width={17}
+                  height={17}
+                  alt="룬 1"
+                />
+                <RuneWithTooltip
+                  iconPath={player.perk}
+                  runeName={player.perkName}
+                  width={17}
+                  height={17}
+                  alt="룬 2"
                 />
               </div>
             </div>
-
-            {/* 7. 받은 피해량 */}
-            <div className="flex flex-col w-full px-2 gap-y-0.5">
-              <div className="flex items-center gap-x-1 text-left">
-                <span className="text-xs md:text-sm tabular-nums">
-                  {player.damageTaken.toLocaleString()}
-                </span>
-              </div>
-              <div className="h-1.5 w-full rounded-full overflow-hidden bg-black">
-                <div
-                  className="h-full rounded-full bg-redText"
-                  style={{ width: `${(player.damageTaken / maxDamageTaken) * 100}%` }}
-                />
-              </div>
+            <div className="grid grid-cols-3 gap-[2px]">
+              {[0, 1, 2, 3, 4, 5].map((slot) =>
+                player.items[slot] !== 0 ? (
+                  <ItemWithTooltip
+                    key={`slot-${slot}`}
+                    itemId={player.items[slot]}
+                    width={17}
+                    height={17}
+                    alt={`아이템 ${slot + 1}`}
+                    className="w-[17px] h-[17px] rounded-[3px]"
+                  />
+                ) : (
+                  <div
+                    key={`empty-slot-${slot}`}
+                    className="w-[17px] h-[17px] rounded-[3px]"
+                    style={{ backgroundColor: "#1C1F24" }}
+                  />
+                )
+              )}
             </div>
+          </div>
 
-            {/* 시야 점수, 제어 와드 개수 */}
-            <div className="flex flex-col items-baseline">
-              <div className="flex gap-x-1.5">
-                <Tooltip content="시야 점수" compact>
-                  <div className="flex items-center justify-center">
-                    <Image
-                      src={EyeIcon}
-                      alt="vision score icon"
-                      width={20}
-                      height={20}
-                      className="w-full h-full object-contain"
-                    />
-                  </div>
-                </Tooltip>
-                <span className="text-sm">{player.visionScore}</span>
-              </div>
-              <div className="flex gap-x-1.5">
-                <Tooltip content="제어 와드 개수" compact>
-                  <div className="flex items-center justify-center w-5 h-5">
-                    <Image
-                      src={WardIcon}
-                      alt="ward icon"
-                      width={20}
-                      height={20}
-                      className="w-full h-full object-contain"
-                    />
-                  </div>
-                </Tooltip>
-                <span className="text-sm">{player.wards}</span>
-              </div>
+          {/* 4. KDA */}
+          <div className="flex flex-col items-center">
+            <span className="text-xs tabular-nums text-primary1">{player.kda}</span>
+            <span className={`text-[11px] font-bold tabular-nums ${getKdaColor(player.kdaRate)}`}>
+              {player.kdaRate.toFixed(2)} KDA
+            </span>
+          </div>
+
+          {/* 5. 관여 */}
+          <div className="text-center text-xs text-primary2 tabular-nums">
+            {player.killParticipation}%
+          </div>
+
+          {/* 6. 가한 피해 */}
+          <div className="flex flex-col gap-1">
+            <span className="text-[11px] tabular-nums text-primary1">
+              {player.damage.toLocaleString()}
+            </span>
+            <div
+              className="h-1.5 w-full rounded-full overflow-hidden"
+              style={{ backgroundColor: "#1C1F24" }}
+            >
+              <div
+                className="h-full rounded-full"
+                style={{
+                  width: `${(player.damage / maxDamage) * 100}%`,
+                  background: "linear-gradient(90deg,#E8913C,#F5C877)",
+                }}
+              />
             </div>
-          </React.Fragment>
-        ))}
-      </div>
+          </div>
+
+          {/* 7. 받은 피해 */}
+          <div className="flex flex-col gap-1">
+            <span className="text-[11px] tabular-nums text-primary1">
+              {player.damageTaken.toLocaleString()}
+            </span>
+            <div
+              className="h-1.5 w-full rounded-full overflow-hidden"
+              style={{ backgroundColor: "#1C1F24" }}
+            >
+              <div
+                className="h-full rounded-full"
+                style={{
+                  width: `${(player.damageTaken / maxDamageTaken) * 100}%`,
+                  backgroundColor: "#6B74A0",
+                }}
+              />
+            </div>
+          </div>
+
+          {/* 8. 시야 */}
+          <div className="flex flex-col items-center gap-0.5">
+            <div className="flex items-center gap-1">
+              <Tooltip content="시야 점수" compact>
+                <div className="flex items-center justify-center w-3.5 h-3.5">
+                  <Image
+                    src={EyeIcon}
+                    alt="vision score icon"
+                    width={14}
+                    height={14}
+                    className="w-full h-full object-contain"
+                  />
+                </div>
+              </Tooltip>
+              <span className="text-xs tabular-nums text-primary1">{player.visionScore}</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <Tooltip content="제어 와드 개수" compact>
+                <div className="flex items-center justify-center w-3 h-3">
+                  <Image
+                    src={WardIcon}
+                    alt="ward icon"
+                    width={12}
+                    height={12}
+                    className="w-full h-full object-contain"
+                  />
+                </div>
+              </Tooltip>
+              <span className="text-[10px] text-primary3 tabular-nums">와드 {player.wards}</span>
+            </div>
+          </div>
+        </div>
+      ))}
     </div>
   );
 };
+
 export default MatchDetailTable;

--- a/src/features/matchHistory/MatchDetailTableMobile.tsx
+++ b/src/features/matchHistory/MatchDetailTableMobile.tsx
@@ -49,8 +49,9 @@ interface MatchDetailProps {
   teamSummary: TeamSummary;
 }
 
-// 챔피언·빌드 / 소환사·아이템 / KDA·관여 / 피해량 / 시야
-const GRID_COLUMNS = "52px minmax(0,1fr) 56px 66px 30px";
+// 챔피언·빌드 / 소환사·아이템 / KDA / 피해량 / 시야
+// 소환사 열(1fr)이 아이템 6개를 한 줄로 담아야 해서 나머지는 좁게 잡는다.
+const GRID_COLUMNS = "48px minmax(0,1fr) 54px 58px 24px";
 
 const MatchDetailTableMobile = ({
   players,
@@ -119,16 +120,16 @@ const MatchDetailTableMobile = ({
           }}
         >
           {/* 1. 챔피언(+레벨) · 스펠 · 룬 */}
-          <div className="flex items-center gap-1">
-            <div className="relative w-[26px] h-[26px] shrink-0">
+          <div className="flex items-center gap-0.5">
+            <div className="relative w-[24px] h-[24px] shrink-0">
               <Tooltip content={player.champName} compact>
                 <SpriteImage
                   spriteData={getChampionSprite(player.champNameEng)}
-                  width={26}
-                  height={26}
+                  width={24}
+                  height={24}
                   alt="챔피언"
                   fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/champion/${player.champNameEng}.png`}
-                  className="w-[26px] h-[26px] rounded-md"
+                  className="w-[24px] h-[24px] rounded-md"
                 />
               </Tooltip>
               <span
@@ -143,33 +144,33 @@ const MatchDetailTableMobile = ({
                 <SpellWithTooltip
                   spellKey={player.spells[0]}
                   spellName={player.spellNames[0]}
-                  width={12}
-                  height={12}
+                  width={11}
+                  height={11}
                   alt="스펠 1"
-                  className="w-[12px] h-[12px] rounded-sm"
+                  className="w-[11px] h-[11px] rounded-sm"
                 />
                 <SpellWithTooltip
                   spellKey={player.spells[1]}
                   spellName={player.spellNames[1]}
-                  width={12}
-                  height={12}
+                  width={11}
+                  height={11}
                   alt="스펠 2"
-                  className="w-[12px] h-[12px] rounded-sm"
+                  className="w-[11px] h-[11px] rounded-sm"
                 />
               </div>
               <div className="flex flex-col gap-px">
                 <RuneWithTooltip
                   iconPath={player.keystone}
                   runeName={player.keystoneName}
-                  width={12}
-                  height={12}
+                  width={11}
+                  height={11}
                   alt="룬 1"
                 />
                 <RuneWithTooltip
                   iconPath={player.perk}
                   runeName={player.perkName}
-                  width={12}
-                  height={12}
+                  width={11}
+                  height={11}
                   alt="룬 2"
                 />
               </div>
@@ -184,21 +185,21 @@ const MatchDetailTableMobile = ({
               isCenter={false}
               className="text-[11px] text-primary1"
             />
-            <div className="mt-0.5 grid grid-cols-3 gap-px w-max">
+            <div className="mt-0.5 flex gap-px overflow-hidden">
               {[0, 1, 2, 3, 4, 5].map((slot) =>
                 player.items[slot] !== 0 ? (
                   <ItemWithTooltip
                     key={`slot-${slot}`}
                     itemId={player.items[slot]}
-                    width={14}
-                    height={14}
+                    width={11}
+                    height={11}
                     alt={`아이템 ${slot + 1}`}
-                    className="w-[14px] h-[14px] rounded-[3px]"
+                    className="w-[11px] h-[11px] rounded-[3px] shrink-0"
                   />
                 ) : (
                   <div
                     key={`empty-slot-${slot}`}
-                    className="w-[14px] h-[14px] rounded-[3px]"
+                    className="w-[11px] h-[11px] rounded-[3px] shrink-0"
                     style={{ backgroundColor: "#1C1F24" }}
                   />
                 )
@@ -206,14 +207,11 @@ const MatchDetailTableMobile = ({
             </div>
           </div>
 
-          {/* 3. KDA · 관여 */}
+          {/* 3. KDA */}
           <div className="flex flex-col items-center leading-tight">
-            <span className="text-[11px] tabular-nums text-primary1">{player.kda}</span>
+            <span className="text-[10px] tabular-nums text-primary1">{player.kda}</span>
             <span className={`text-[10px] font-bold tabular-nums ${getKdaColor(player.kdaRate)}`}>
               {player.kdaRate.toFixed(2)}
-            </span>
-            <span className="text-[9px] text-primary3 tabular-nums">
-              관여 {player.killParticipation}%
             </span>
           </div>
 

--- a/src/features/matchHistory/MatchDetailTableMobile.tsx
+++ b/src/features/matchHistory/MatchDetailTableMobile.tsx
@@ -147,10 +147,16 @@ const MatchDetailTableMobile = ({
                 />
                 <span className="tabular-nums">{player.damage.toLocaleString()}</span>
               </div>
-              <div className="h-1 w-full rounded-full overflow-hidden bg-black">
+              <div
+                className="h-1 w-full rounded-full overflow-hidden"
+                style={{ backgroundColor: "#1C1F24" }}
+              >
                 <div
-                  className="h-full rounded-full bg-blueText"
-                  style={{ width: `${(player.damage / maxDamage) * 100}%` }}
+                  className="h-full rounded-full"
+                  style={{
+                    width: `${(player.damage / maxDamage) * 100}%`,
+                    background: "linear-gradient(90deg,#E8913C,#F5C877)",
+                  }}
                 />
               </div>
               <div className="flex items-center gap-x-1 mt-0.5">
@@ -163,10 +169,16 @@ const MatchDetailTableMobile = ({
                 />
                 <span className="tabular-nums">{player.damageTaken.toLocaleString()}</span>
               </div>
-              <div className="h-1 w-full rounded-full overflow-hidden bg-black">
+              <div
+                className="h-1 w-full rounded-full overflow-hidden"
+                style={{ backgroundColor: "#1C1F24" }}
+              >
                 <div
-                  className="h-full rounded-full bg-redText"
-                  style={{ width: `${(player.damageTaken / maxDamageTaken) * 100}%` }}
+                  className="h-full rounded-full"
+                  style={{
+                    width: `${(player.damageTaken / maxDamageTaken) * 100}%`,
+                    backgroundColor: "#6B74A0",
+                  }}
                 />
               </div>
             </div>

--- a/src/features/matchHistory/MatchDetailTableMobile.tsx
+++ b/src/features/matchHistory/MatchDetailTableMobile.tsx
@@ -1,9 +1,7 @@
 import Image from "next/image";
 import React from "react";
 import PlayerNameButton from "@/features/matchHistory/PlayerNameButton";
-import ShieldIcon from "@/assets/images/shield.png";
 import EyeIcon from "@/assets/images/eye.png";
-import SwordIcon from "@/assets/images/sword.png";
 import WardIcon from "@/assets/images/ward.png";
 import SpriteImage from "@/components/ui/SpriteImage";
 import Tooltip from "@/components/ui/Tooltip";
@@ -18,6 +16,7 @@ interface Player {
   tag: string;
   champName: string;
   champNameEng: string;
+  level: number;
   kda: string;
   kdaRate: number;
   damage: number;
@@ -34,119 +33,196 @@ interface Player {
   killParticipation: number;
 }
 
+interface TeamSummary {
+  kills: number;
+  deaths: number;
+  assists: number;
+  damage: number;
+}
+
 interface MatchDetailProps {
   players: Player[];
   isWin: boolean;
   maxDamage: number;
   maxDamageTaken: number;
+  teamLabel: string;
+  teamSummary: TeamSummary;
 }
+
+// 챔피언·빌드 / 소환사·아이템 / KDA·관여 / 피해량 / 시야
+const GRID_COLUMNS = "52px minmax(0,1fr) 56px 66px 30px";
 
 const MatchDetailTableMobile = ({
   players,
   isWin,
   maxDamage,
   maxDamageTaken,
+  teamLabel,
+  teamSummary,
 }: MatchDetailProps) => {
+  const accent = isWin ? "#58A6FF" : "#F2789F";
+  const accentRgb = isWin ? "88,166,255" : "242,120,159";
+  const headerBg = isWin ? "#0E1A2B" : "#241019";
+  const rowTint = `rgba(${accentRgb},0.04)`;
+  const pillBg = `rgba(${accentRgb},0.14)`;
+
   return (
-    <div className={`${isWin ? "bg-blueLighten" : "bg-redLighten"} rounded-md text-xs p-0.5`}>
-      <div className="grid grid-cols-[1fr_1fr_1fr_1fr_0.7fr] place-items-center text-center gap-y-1 py-[2px]">
-        {/* 데이터 행 */}
-        {players.map((player) => (
-          <React.Fragment key={`${player.name}-${player.tag}`}>
-            {/* 1. 챔피언 이미지, 룬 스펠 */}
-            <div className="flex gap-1 w-[56px] h-[24px]">
+    <div className="w-full min-w-0 bg-darkBg2 border border-cardBorder rounded-[10px] overflow-hidden text-xs">
+      {/* 팀 요약 헤더 */}
+      <div
+        className="flex items-center justify-between py-1.5 pr-3"
+        style={{ backgroundColor: headerBg, borderLeft: `3px solid ${accent}` }}
+      >
+        <div className="flex items-center gap-2 pl-2.5 min-w-0">
+          <span
+            className="text-[10px] font-bold rounded px-1.5 py-0.5 shrink-0"
+            style={{ color: accent, backgroundColor: pillBg }}
+          >
+            {isWin ? "승리" : "패배"}
+          </span>
+          <span className="text-[10px] text-primary2 truncate">{teamLabel}</span>
+        </div>
+        <div className="flex items-center gap-2.5 text-[10px] tabular-nums shrink-0">
+          <span className="text-primary2">
+            <span className="text-primary1 font-bold">
+              {teamSummary.kills} / {teamSummary.deaths} / {teamSummary.assists}
+            </span>
+          </span>
+          <span className="text-primary2">
+            딜{" "}
+            <span className="text-primary1 font-bold">{teamSummary.damage.toLocaleString()}</span>
+          </span>
+        </div>
+      </div>
+
+      {/* 열 제목 */}
+      <div
+        className="grid items-center gap-1.5 px-2 py-1 text-[10px] text-primary3 text-center"
+        style={{ gridTemplateColumns: GRID_COLUMNS }}
+      >
+        <div />
+        <div className="text-left">소환사</div>
+        <div>KDA</div>
+        <div>피해량</div>
+        <div>시야</div>
+      </div>
+
+      {/* 플레이어 행 */}
+      {players.map((player) => (
+        <div
+          key={`${player.name}-${player.tag}`}
+          className="grid items-center gap-1.5 px-2 py-1.5"
+          style={{
+            gridTemplateColumns: GRID_COLUMNS,
+            backgroundColor: rowTint,
+            borderBottom: "1px solid #141619",
+          }}
+        >
+          {/* 1. 챔피언(+레벨) · 스펠 · 룬 */}
+          <div className="flex items-center gap-1">
+            <div className="relative w-[26px] h-[26px] shrink-0">
               <Tooltip content={player.champName} compact>
                 <SpriteImage
                   spriteData={getChampionSprite(player.champNameEng)}
-                  width={24}
-                  height={24}
+                  width={26}
+                  height={26}
                   alt="챔피언"
                   fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/champion/${player.champNameEng}.png`}
-                  className="w-[24px] h-[24px]"
+                  className="w-[26px] h-[26px] rounded-md"
                 />
               </Tooltip>
-              <div className="flex">
-                <div className="flex flex-col gap-0">
-                  <SpellWithTooltip
-                    spellKey={player.spells[0]}
-                    spellName={player.spellNames[0]}
-                    width={12}
-                    height={12}
-                    alt="스펠 1"
-                    className="w-[12px] h-[12px]"
-                  />
-                  <SpellWithTooltip
-                    spellKey={player.spells[1]}
-                    spellName={player.spellNames[1]}
-                    width={12}
-                    height={12}
-                    alt="스펠 2"
-                    className="w-[12px] h-[12px]"
-                  />
-                </div>
-                <div className="flex flex-col gap-0">
-                  <RuneWithTooltip
-                    iconPath={player.keystone}
-                    runeName={player.keystoneName}
-                    width={12}
-                    height={12}
-                    alt="룬 1"
-                  />
-                  <RuneWithTooltip
-                    iconPath={player.perk}
-                    runeName={player.perkName}
-                    width={12}
-                    height={12}
-                    alt="룬 2"
-                  />
-                </div>
-              </div>
-            </div>
-
-            {/* 2. 챔피언 이름, 아이템 */}
-            <div className="flex flex-col gap-x-1 text-left justify-self-start w-[72px] max-w-[72px]">
-              <PlayerNameButton name={player.name} tag={player.tag} isCenter={false} />
-              <div className="w-[72px] flex gap-px">
-                {[0, 1, 2, 3, 4, 5].map((slot) =>
-                  player.items[slot] !== 0 ? (
-                    <ItemWithTooltip
-                      key={`slot-${slot}`}
-                      itemId={player.items[slot]}
-                      width={12}
-                      height={12}
-                      alt={`아이템 ${slot + 1}`}
-                      className="w-[12px] h-[12px]"
-                    />
-                  ) : (
-                    <div
-                      key={`empty-slot-${slot}`}
-                      className="w-[12px] h-[12px] rounded-[4px] bg-border1 shrink-0"
-                    />
-                  )
-                )}
-              </div>
-            </div>
-
-            {/* 4. KDA */}
-            <div className="flex flex-col">
-              <span>{player.kda}</span>
-              <span className={`text-xs font-semibold ${getKdaColor(player.kdaRate)}`}>
-                {player.kdaRate.toFixed(2)} KDA
+              <span
+                className="absolute -bottom-1 -right-1 text-[8px] font-bold leading-none text-primary1 rounded px-0.5 py-px border border-border1"
+                style={{ backgroundColor: "#0A0B0D" }}
+              >
+                {player.level}
               </span>
             </div>
-
-            {/* 6. 준 피해량, 받은 피해량 */}
-            <div className="flex flex-col w-full px-1 gap-y-0.5">
-              <div className="flex items-center gap-x-1">
-                <Image
-                  src={SwordIcon}
-                  alt="sword icon"
-                  width={10}
-                  height={10}
-                  className="shrink-0"
+            <div className="flex">
+              <div className="flex flex-col gap-px">
+                <SpellWithTooltip
+                  spellKey={player.spells[0]}
+                  spellName={player.spellNames[0]}
+                  width={12}
+                  height={12}
+                  alt="스펠 1"
+                  className="w-[12px] h-[12px] rounded-sm"
                 />
-                <span className="tabular-nums">{player.damage.toLocaleString()}</span>
+                <SpellWithTooltip
+                  spellKey={player.spells[1]}
+                  spellName={player.spellNames[1]}
+                  width={12}
+                  height={12}
+                  alt="스펠 2"
+                  className="w-[12px] h-[12px] rounded-sm"
+                />
               </div>
+              <div className="flex flex-col gap-px">
+                <RuneWithTooltip
+                  iconPath={player.keystone}
+                  runeName={player.keystoneName}
+                  width={12}
+                  height={12}
+                  alt="룬 1"
+                />
+                <RuneWithTooltip
+                  iconPath={player.perk}
+                  runeName={player.perkName}
+                  width={12}
+                  height={12}
+                  alt="룬 2"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* 2. 소환사 · 아이템 */}
+          <div className="min-w-0">
+            <PlayerNameButton
+              name={player.name}
+              tag={player.tag}
+              isCenter={false}
+              className="text-[11px] text-primary1"
+            />
+            <div className="mt-0.5 grid grid-cols-3 gap-px w-max">
+              {[0, 1, 2, 3, 4, 5].map((slot) =>
+                player.items[slot] !== 0 ? (
+                  <ItemWithTooltip
+                    key={`slot-${slot}`}
+                    itemId={player.items[slot]}
+                    width={14}
+                    height={14}
+                    alt={`아이템 ${slot + 1}`}
+                    className="w-[14px] h-[14px] rounded-[3px]"
+                  />
+                ) : (
+                  <div
+                    key={`empty-slot-${slot}`}
+                    className="w-[14px] h-[14px] rounded-[3px]"
+                    style={{ backgroundColor: "#1C1F24" }}
+                  />
+                )
+              )}
+            </div>
+          </div>
+
+          {/* 3. KDA · 관여 */}
+          <div className="flex flex-col items-center leading-tight">
+            <span className="text-[11px] tabular-nums text-primary1">{player.kda}</span>
+            <span className={`text-[10px] font-bold tabular-nums ${getKdaColor(player.kdaRate)}`}>
+              {player.kdaRate.toFixed(2)}
+            </span>
+            <span className="text-[9px] text-primary3 tabular-nums">
+              관여 {player.killParticipation}%
+            </span>
+          </div>
+
+          {/* 4. 가한/받은 피해 */}
+          <div className="flex flex-col gap-1">
+            <div>
+              <span className="text-[9px] tabular-nums text-primary1">
+                {player.damage.toLocaleString()}
+              </span>
               <div
                 className="h-1 w-full rounded-full overflow-hidden"
                 style={{ backgroundColor: "#1C1F24" }}
@@ -159,16 +235,11 @@ const MatchDetailTableMobile = ({
                   }}
                 />
               </div>
-              <div className="flex items-center gap-x-1 mt-0.5">
-                <Image
-                  src={ShieldIcon}
-                  alt="shield icon"
-                  width={10}
-                  height={10}
-                  className="shrink-0"
-                />
-                <span className="tabular-nums">{player.damageTaken.toLocaleString()}</span>
-              </div>
+            </div>
+            <div>
+              <span className="text-[9px] tabular-nums text-primary1">
+                {player.damageTaken.toLocaleString()}
+              </span>
               <div
                 className="h-1 w-full rounded-full overflow-hidden"
                 style={{ backgroundColor: "#1C1F24" }}
@@ -182,41 +253,41 @@ const MatchDetailTableMobile = ({
                 />
               </div>
             </div>
+          </div>
 
-            {/* 시야 점수, 제어 와드 개수 */}
-            <div className="flex flex-col items-baseline">
-              <div className="flex gap-x-1.5 items-center">
-                <Tooltip content="시야 점수" compact>
-                  <div className="flex items-center justify-center w-4 h-4">
-                    <Image
-                      src={EyeIcon}
-                      alt="vision score icon"
-                      width={16}
-                      height={16}
-                      className="w-full h-full object-contain"
-                    />
-                  </div>
-                </Tooltip>
-                <span>{player.visionScore}</span>
-              </div>
-              <div className="flex gap-x-1.5 items-center">
-                <Tooltip content="제어 와드 개수" compact>
-                  <div className="flex items-center justify-center w-4 h-4">
-                    <Image
-                      src={WardIcon}
-                      alt="ward icon"
-                      width={16}
-                      height={16}
-                      className="w-full h-full object-contain"
-                    />
-                  </div>
-                </Tooltip>
-                <span>{player.wards}</span>
-              </div>
+          {/* 5. 시야 */}
+          <div className="flex flex-col items-center gap-0.5">
+            <div className="flex items-center gap-0.5">
+              <Tooltip content="시야 점수" compact>
+                <div className="flex items-center justify-center w-3 h-3">
+                  <Image
+                    src={EyeIcon}
+                    alt="vision score icon"
+                    width={12}
+                    height={12}
+                    className="w-full h-full object-contain"
+                  />
+                </div>
+              </Tooltip>
+              <span className="text-[10px] tabular-nums text-primary1">{player.visionScore}</span>
             </div>
-          </React.Fragment>
-        ))}
-      </div>
+            <div className="flex items-center gap-0.5">
+              <Tooltip content="제어 와드 개수" compact>
+                <div className="flex items-center justify-center w-2.5 h-2.5">
+                  <Image
+                    src={WardIcon}
+                    alt="ward icon"
+                    width={10}
+                    height={10}
+                    className="w-full h-full object-contain"
+                  />
+                </div>
+              </Tooltip>
+              <span className="text-[9px] text-primary3 tabular-nums">{player.wards}</span>
+            </div>
+          </div>
+        </div>
+      ))}
     </div>
   );
 };

--- a/src/features/matchHistory/MatchItem.tsx
+++ b/src/features/matchHistory/MatchItem.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { MdKeyboardArrowDown } from "react-icons/md";
 import MatchDetail from "@/features/matchHistory/MatchDetail";
 import { GameRecordResponse, RecentGameRecord } from "@/data/types/record";
 import { useQuery } from "@tanstack/react-query";
@@ -270,11 +269,20 @@ const MatchItem = ({ matchData }: Props) => {
           }`}
         >
           <span className="sr-only">펼치기</span>
-          <MdKeyboardArrowDown
-            className={`text-xl transition-transform duration-150 ${
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+            className={`w-5 h-5 transition-transform duration-150 ${
               isOpen ? "rotate-180" : "rotate-0"
             } ${isWin ? "text-blueButton" : "text-redButton"}`}
-          />
+          >
+            <path d="M6 9l6 6 6-6" />
+          </svg>
         </button>
       </div>
 

--- a/src/features/matchHistory/MatchItem.tsx
+++ b/src/features/matchHistory/MatchItem.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import MatchDetail from "@/features/matchHistory/MatchDetail";
 import { GameRecordResponse, RecentGameRecord } from "@/data/types/record";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ApiResponse } from "@/services/apiService";
 import { getGameRecords } from "@/services/record";
 import { formatTimeAgo } from "@/utils/parseTime";
@@ -26,14 +26,30 @@ const MatchItem = ({ matchData }: Props) => {
   const guildId =
     typeof window !== "undefined" ? (localStorage.getItem("guildId") ?? undefined) : undefined;
 
+  const queryClient = useQueryClient();
+  const gameQueryKey = ["gameData", matchData.gameId, guildId];
+  const gameStaleTime = 3 * 60 * 1000;
+
   const { data: gameData, isLoading: isLoadingGameData } = useQuery<
     ApiResponse<GameRecordResponse>
   >({
-    queryKey: ["gameData", matchData.gameId, guildId],
+    queryKey: gameQueryKey,
     queryFn: () => getGameRecords(matchData.gameId, guildId),
-    staleTime: 3 * 60 * 1000,
+    staleTime: gameStaleTime,
     enabled: isOpen && !!guildId,
   });
+
+  const prefetchGameData = () => {
+    if (!guildId) return;
+    queryClient.prefetchQuery({
+      queryKey: gameQueryKey,
+      queryFn: () => getGameRecords(matchData.gameId, guildId),
+      staleTime: gameStaleTime,
+    });
+  };
+
+  const detailData = gameData?.data?.data;
+  const showDetail = isOpen && !isLoadingGameData && !!detailData;
 
   const itemArr = [
     { slot: 0, itemId: matchData.item0 },
@@ -58,6 +74,8 @@ const MatchItem = ({ matchData }: Props) => {
         role="button"
         tabIndex={0}
         onClick={toggleOpen}
+        onMouseEnter={prefetchGameData}
+        onFocus={prefetchGameData}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") toggleOpen();
         }}
@@ -286,22 +304,25 @@ const MatchItem = ({ matchData }: Props) => {
         </button>
       </div>
 
+      {isOpen && isLoadingGameData && (
+        <div className="pt-1.5 flex justify-center">
+          <LoadingSpinner />
+        </div>
+      )}
+
       <div
         className={`grid transition-[grid-template-rows,opacity] duration-300 ease-out ${
-          isOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
+          showDetail ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
         }`}
       >
         <div className="overflow-hidden min-h-0">
-          {isOpen && (
-            <div className="pt-1.5">
-              {isLoadingGameData && <LoadingSpinner />}
-              {!isLoadingGameData && gameData?.data?.data && (
-                <div className="flex flex-col w-full min-w-0">
-                  <MatchDetail participantData={gameData.data.data} />
-                </div>
-              )}
-            </div>
-          )}
+          <div className="pt-1.5">
+            {detailData && (
+              <div className="flex flex-col w-full min-w-0">
+                <MatchDetail participantData={detailData} />
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/features/matchHistory/MatchItem.tsx
+++ b/src/features/matchHistory/MatchItem.tsx
@@ -286,14 +286,12 @@ const MatchItem = ({ matchData }: Props) => {
         </button>
       </div>
 
-      {/* grid-rows 0fr→1fr 트랜지션: 상세 콘텐츠의 실제 높이를 몰라도 부드럽게 펼침 */}
       <div
         className={`grid transition-[grid-template-rows,opacity] duration-300 ease-out ${
           isOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
         }`}
       >
         <div className="overflow-hidden min-h-0">
-          {/* pt-1.5로 기존 gap 대체 — 닫히면 clip에 잘려 여백이 사라짐 */}
           {isOpen && (
             <div className="pt-1.5">
               {isLoadingGameData && <LoadingSpinner />}

--- a/src/features/matchHistory/MatchItem.tsx
+++ b/src/features/matchHistory/MatchItem.tsx
@@ -53,7 +53,7 @@ const MatchItem = ({ matchData }: Props) => {
   const durationSec = String(matchData.timePlayed % 60).padStart(2, "0");
 
   return (
-    <div className="flex flex-col gap-1.5">
+    <div className="flex flex-col">
       <div
         role="button"
         tabIndex={0}
@@ -286,16 +286,26 @@ const MatchItem = ({ matchData }: Props) => {
         </button>
       </div>
 
-      {isOpen && (
-        <>
-          {isLoadingGameData && <LoadingSpinner />}
-          {!isLoadingGameData && gameData?.data?.data && (
-            <div className="flex flex-col w-full min-w-0">
-              <MatchDetail participantData={gameData.data.data} />
+      {/* grid-rows 0fr→1fr 트랜지션: 상세 콘텐츠의 실제 높이를 몰라도 부드럽게 펼침 */}
+      <div
+        className={`grid transition-[grid-template-rows,opacity] duration-300 ease-out ${
+          isOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
+        }`}
+      >
+        <div className="overflow-hidden min-h-0">
+          {/* pt-1.5로 기존 gap 대체 — 닫히면 clip에 잘려 여백이 사라짐 */}
+          {isOpen && (
+            <div className="pt-1.5">
+              {isLoadingGameData && <LoadingSpinner />}
+              {!isLoadingGameData && gameData?.data?.data && (
+                <div className="flex flex-col w-full min-w-0">
+                  <MatchDetail participantData={gameData.data.data} />
+                </div>
+              )}
             </div>
           )}
-        </>
-      )}
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/features/matchHistory/MatchItem.tsx
+++ b/src/features/matchHistory/MatchItem.tsx
@@ -290,7 +290,7 @@ const MatchItem = ({ matchData }: Props) => {
         <>
           {isLoadingGameData && <LoadingSpinner />}
           {!isLoadingGameData && gameData?.data?.data && (
-            <div className="flex flex-col w-full">
+            <div className="flex flex-col w-full min-w-0">
               <MatchDetail participantData={gameData.data.data} />
             </div>
           )}

--- a/src/features/matchHistory/MatchItem.tsx
+++ b/src/features/matchHistory/MatchItem.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import MatchDetail from "@/features/matchHistory/MatchDetail";
 import { GameRecordResponse, RecentGameRecord } from "@/data/types/record";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { ApiResponse } from "@/services/apiService";
 import { getGameRecords } from "@/services/record";
 import { formatTimeAgo } from "@/utils/parseTime";
@@ -26,27 +26,14 @@ const MatchItem = ({ matchData }: Props) => {
   const guildId =
     typeof window !== "undefined" ? (localStorage.getItem("guildId") ?? undefined) : undefined;
 
-  const queryClient = useQueryClient();
-  const gameQueryKey = ["gameData", matchData.gameId, guildId];
-  const gameStaleTime = 3 * 60 * 1000;
-
   const { data: gameData, isLoading: isLoadingGameData } = useQuery<
     ApiResponse<GameRecordResponse>
   >({
-    queryKey: gameQueryKey,
+    queryKey: ["gameData", matchData.gameId, guildId],
     queryFn: () => getGameRecords(matchData.gameId, guildId),
-    staleTime: gameStaleTime,
+    staleTime: 3 * 60 * 1000,
     enabled: isOpen && !!guildId,
   });
-
-  const prefetchGameData = () => {
-    if (!guildId) return;
-    queryClient.prefetchQuery({
-      queryKey: gameQueryKey,
-      queryFn: () => getGameRecords(matchData.gameId, guildId),
-      staleTime: gameStaleTime,
-    });
-  };
 
   const detailData = gameData?.data?.data;
   const showDetail = isOpen && !isLoadingGameData && !!detailData;
@@ -74,8 +61,6 @@ const MatchItem = ({ matchData }: Props) => {
         role="button"
         tabIndex={0}
         onClick={toggleOpen}
-        onMouseEnter={prefetchGameData}
-        onFocus={prefetchGameData}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") toggleOpen();
         }}

--- a/src/features/matchHistory/MostPickRank.tsx
+++ b/src/features/matchHistory/MostPickRank.tsx
@@ -26,9 +26,19 @@ const MostPickRank = ({ mostPickData }: Props) => {
 
   return (
     <div className="flex flex-col">
-      {displayedData.map((data) => (
-        <RankItem key={data.rank} {...data} />
-      ))}
+      {displayedData.map((data, i) => {
+        // 더보기로 새로 나타난 항목(초기 5개 이후)만 순차 등장
+        const isNew = i >= INITIAL_DISPLAY_COUNT;
+        return (
+          <div
+            key={data.rank}
+            className={isNew ? "animate-fadeUp" : undefined}
+            style={isNew ? { animationDelay: `${(i - INITIAL_DISPLAY_COUNT) * 60}ms` } : undefined}
+          >
+            <RankItem {...data} />
+          </div>
+        );
+      })}
 
       {hasMore && !showAll && (
         <button

--- a/src/features/matchHistory/MostPickRank.tsx
+++ b/src/features/matchHistory/MostPickRank.tsx
@@ -25,7 +25,7 @@ const MostPickRank = ({ mostPickData }: Props) => {
   const hasMore = rankData.length > INITIAL_DISPLAY_COUNT;
 
   return (
-    <div className="flex flex-col gap-2 sm:gap-4">
+    <div className="flex flex-col">
       {displayedData.map((data) => (
         <RankItem key={data.rank} {...data} />
       ))}
@@ -34,7 +34,7 @@ const MostPickRank = ({ mostPickData }: Props) => {
         <button
           type="button"
           onClick={() => setShowAll(true)}
-          className="w-full py-2 rounded bg-darkBg1 border border-border2 text-primary2 hover:bg-grayHover transition-colors text-sm"
+          className="mt-2 w-full py-2 rounded bg-darkBg1 border border-border2 text-primary2 hover:bg-grayHover transition-colors text-sm"
         >
           더보기
         </button>

--- a/src/features/matchHistory/MostPickRank.tsx
+++ b/src/features/matchHistory/MostPickRank.tsx
@@ -27,7 +27,6 @@ const MostPickRank = ({ mostPickData }: Props) => {
   return (
     <div className="flex flex-col">
       {displayedData.map((data, i) => {
-        // 더보기로 새로 나타난 항목(초기 5개 이후)만 순차 등장
         const isNew = i >= INITIAL_DISPLAY_COUNT;
         return (
           <div

--- a/src/features/matchHistory/MostPickRank.tsx
+++ b/src/features/matchHistory/MostPickRank.tsx
@@ -32,7 +32,7 @@ const MostPickRank = ({ mostPickData }: Props) => {
         return (
           <div
             key={data.rank}
-            className={isNew ? "animate-fadeUp" : undefined}
+            className={isNew ? "motion-safe:animate-fadeUp" : undefined}
             style={isNew ? { animationDelay: `${(i - INITIAL_DISPLAY_COUNT) * 60}ms` } : undefined}
           >
             <RankItem {...data} />

--- a/src/features/matchHistory/PlayerNameButton.tsx
+++ b/src/features/matchHistory/PlayerNameButton.tsx
@@ -14,14 +14,16 @@ const PlayerNameButton = ({
 }) => {
   return (
     <div className="relative group min-w-0 w-full">
-      {/* 레거시 next/link는 className을 <a>로 전달하지 않으므로, 말줄임 스타일은
-          NavBar와 동일하게 자식 요소(span)에 직접 적용한다. */}
-      <Link href={`/summoners/${encodeURIComponent(name)}/${encodeURIComponent(tag)}`}>
-        <span
+      {/* 레거시 next/link(Next 12)는 className을 <a>로 전달하지 않으므로, 실제 <a href>를
+          자식으로 두어 우클릭 → 새 탭 열기를 지원하고 말줄임 스타일은 <a>에 직접 적용한다. */}
+      <Link href={`/summoners/${encodeURIComponent(name)}/${encodeURIComponent(tag)}`} passHref>
+        {/* href는 passHref로 런타임에 주입되므로 정적 분석 규칙을 이 <a>에 한해 비활성화 */}
+        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+        <a
           className={`block truncate w-full cursor-pointer ${isCenter ? "text-center" : "text-left"} ${className ?? ""}`}
         >
           {name}
-        </span>
+        </a>
       </Link>
       <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 hidden group-hover:block px-3 py-1 rounded bg-black text-white z-10 whitespace-nowrap w-max">
         <span>{name}</span>

--- a/src/features/matchHistory/PlayerNameButton.tsx
+++ b/src/features/matchHistory/PlayerNameButton.tsx
@@ -14,11 +14,14 @@ const PlayerNameButton = ({
 }) => {
   return (
     <div className="relative group min-w-0 w-full">
-      <Link
-        href={`/summoners/${encodeURIComponent(name)}/${encodeURIComponent(tag)}`}
-        className={`block truncate w-full overflow-hidden whitespace-nowrap ${isCenter ? "text-center" : "text-left"} ${className}`}
-      >
-        {name}
+      {/* 레거시 next/link는 className을 <a>로 전달하지 않으므로, 말줄임 스타일은
+          NavBar와 동일하게 자식 요소(span)에 직접 적용한다. */}
+      <Link href={`/summoners/${encodeURIComponent(name)}/${encodeURIComponent(tag)}`}>
+        <span
+          className={`block truncate w-full cursor-pointer ${isCenter ? "text-center" : "text-left"} ${className ?? ""}`}
+        >
+          {name}
+        </span>
       </Link>
       <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 hidden group-hover:block px-3 py-1 rounded bg-black text-white z-10 whitespace-nowrap w-max">
         <span>{name}</span>

--- a/src/features/matchHistory/PositionStats.tsx
+++ b/src/features/matchHistory/PositionStats.tsx
@@ -103,11 +103,7 @@ const PositionStats = ({ linesData }: Props) => {
               <span className={`text-xs tabular-nums ${getKdaColor(line.kda)}`}>
                 {line.kda} KDA
               </span>
-              <span
-                className={`font-bold tabular-nums ${getWinRateColor(line.winRate)} ${
-                  isPrimary ? "text-base" : "text-sm"
-                }`}
-              >
+              <span className={`text-sm font-bold tabular-nums ${getWinRateColor(line.winRate)}`}>
                 {line.winRate}%
               </span>
             </div>

--- a/src/features/matchHistory/PositionStats.tsx
+++ b/src/features/matchHistory/PositionStats.tsx
@@ -5,7 +5,7 @@ import LaneMidLogo from "@/assets/images/laneMid.png";
 import LaneSupportLogo from "@/assets/images/laneSupport.png";
 import LaneBottomLogo from "@/assets/images/laneBottom.png";
 import { LineStats } from "@/data/types/record";
-import { getKdaColor } from "@/utils/statColors";
+import { getKdaColor, getWinRateColor } from "@/utils/statColors";
 
 interface Props {
   linesData: LineStats[];
@@ -19,6 +19,14 @@ const laneImageMap: Record<string, StaticImageData> = {
   SUP: LaneSupportLogo,
 };
 
+const laneLabelMap: Record<string, string> = {
+  TOP: "탑",
+  JUG: "정글",
+  MID: "미드",
+  ADC: "원딜",
+  SUP: "서폿",
+};
+
 const POSITION_ORDER: Array<"TOP" | "JUG" | "MID" | "ADC" | "SUP"> = [
   "TOP",
   "JUG",
@@ -28,7 +36,7 @@ const POSITION_ORDER: Array<"TOP" | "JUG" | "MID" | "ADC" | "SUP"> = [
 ];
 
 const PositionStats = ({ linesData }: Props) => {
-  // 포지션 순서대로 정렬
+  // 포지션 순서대로 정렬(재정렬 없음)
   const sortedLines = POSITION_ORDER.map(
     (position) =>
       linesData.find((line) => line.position === position) || {
@@ -41,39 +49,71 @@ const PositionStats = ({ linesData }: Props) => {
       }
   );
 
-  return (
-    <div className="flex flex-col gap-1 sm:gap-4">
-      {sortedLines.map((line) => (
-        <div
-          key={line.position}
-          className="bg-darkBg1 rounded border border-border2 p-2 sm:p-3 flex items-center gap-2 sm:gap-4"
-        >
-          {/* 라인 아이콘 */}
-          <div className="shrink-0 w-8 h-8 sm:w-12 sm:h-12">
-            <Image
-              src={laneImageMap[line.position]}
-              alt={line.position}
-              width={48}
-              height={48}
-              className="w-full h-full object-contain"
-            />
-          </div>
+  // 주 포지션(최다 판수) — 판수가 있을 때만 강조
+  const maxGames = Math.max(...sortedLines.map((line) => line.totalCount));
+  const primaryPosition =
+    maxGames > 0 ? sortedLines.find((line) => line.totalCount === maxGames)?.position : undefined;
 
-          {/* 통계 정보 */}
-          <div className="flex-1 flex items-center justify-between">
-            <div>
-              <div className="text-xs sm:text-sm text-primary1">
+  return (
+    <div className="flex flex-col gap-1">
+      {sortedLines.map((line) => {
+        const isPrimary = line.position === primaryPosition;
+        return (
+          <div
+            key={line.position}
+            className={`flex items-center gap-3 rounded-lg p-2.5 ${
+              isPrimary
+                ? "bg-primaryLaneBg border border-primaryLaneBorder"
+                : "border border-transparent"
+            }`}
+          >
+            {/* 라인 아이콘 32×32 */}
+            <div className="shrink-0 w-8 h-8">
+              <Image
+                src={laneImageMap[line.position]}
+                alt={line.position}
+                width={32}
+                height={32}
+                className="w-full h-full object-contain"
+              />
+            </div>
+
+            {/* 라인 라벨 + 전적 */}
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-1.5">
+                <span className={`text-sm ${isPrimary ? "font-bold text-white" : "text-primary1"}`}>
+                  {laneLabelMap[line.position]}
+                </span>
+                {isPrimary && (
+                  <span
+                    className="text-[11px] font-bold text-teamWin rounded px-1.5 py-0.5"
+                    style={{ backgroundColor: "rgba(88,166,255,0.14)" }}
+                  >
+                    주 포지션
+                  </span>
+                )}
+              </div>
+              <div className="text-[11px] text-primary2 mt-0.5 tabular-nums">
                 {line.totalCount}전 {line.win}승 {line.lose}패
               </div>
-              <div className="text-xs text-primary2 mt-0.5 sm:mt-1">({line.winRate}%)</div>
             </div>
 
-            <div className="text-right">
-              <div className={`text-xs sm:text-sm ${getKdaColor(line.kda)}`}>{line.kda} KDA</div>
+            {/* KDA + 승률 */}
+            <div className="flex items-center gap-3 shrink-0">
+              <span className={`text-xs tabular-nums ${getKdaColor(line.kda)}`}>
+                {line.kda} KDA
+              </span>
+              <span
+                className={`font-bold tabular-nums ${getWinRateColor(line.winRate)} ${
+                  isPrimary ? "text-base" : "text-sm"
+                }`}
+              >
+                {line.winRate}%
+              </span>
             </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 };

--- a/src/features/matchHistory/RankItem.tsx
+++ b/src/features/matchHistory/RankItem.tsx
@@ -48,7 +48,7 @@ const RankItem: React.FC<RankItemProps> = ({
 
       {/* 승률 */}
       <div
-        className={`w-11 shrink-0 text-right text-[13px] font-bold tabular-nums ${getWinRateColor(winRate)}`}
+        className={`w-11 shrink-0 text-right text-sm font-bold tabular-nums ${getWinRateColor(winRate)}`}
       >
         {winRate}%
       </div>

--- a/src/features/matchHistory/RankItem.tsx
+++ b/src/features/matchHistory/RankItem.tsx
@@ -12,12 +12,6 @@ interface RankItemProps {
   games: number;
 }
 
-const getRankBgColor = (rank: number): string => {
-  if (rank === 1) return "bg-rankBg1";
-  if (rank === 2 || rank === 3) return "bg-rankBg2";
-  return "bg-rankBg3";
-};
-
 const RankItem: React.FC<RankItemProps> = ({
   rank,
   championName,
@@ -27,48 +21,36 @@ const RankItem: React.FC<RankItemProps> = ({
   games,
 }) => {
   return (
-    <div className="flex h-[28px] sm:h-[52px] items-center justify-between md:justify-center">
+    <div className="flex items-center gap-[11px] px-1.5 py-[9px]">
       {/* 순위 */}
-      <div
-        className={`w-[21px] h-[28px] sm:h-[52px] ${getRankBgColor(rank)} text-primary2 text-center text-lg font-bold flex items-center justify-center`}
-      >
+      <div className="w-3.5 shrink-0 text-center text-[13px] font-bold text-primary2 tabular-nums">
         {rank}
       </div>
 
-      {/* 챔피언 아이콘 */}
-      <div className="flex items-center justify-center shrink-0 flex-none ml-1">
-        {/* 모바일 */}
-        <SpriteImage
-          spriteData={getChampionSprite(championNameEng)}
-          alt={championName}
-          width={28}
-          height={28}
-          fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/champion/${championNameEng}.png`}
-          className="w-7 h-7 sm:hidden"
-        />
-        {/* 데스크탑 */}
-        <SpriteImage
-          spriteData={getChampionSprite(championNameEng)}
-          alt={championName}
-          width={52}
-          height={52}
-          fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/champion/${championNameEng}.png`}
-          className="hidden sm:block w-[52px] h-[52px]"
-        />
-      </div>
+      {/* 챔피언 아이콘 40×40, radius 8, border */}
+      <SpriteImage
+        spriteData={getChampionSprite(championNameEng)}
+        alt={championName}
+        width={40}
+        height={40}
+        fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/champion/${championNameEng}.png`}
+        className="w-10 h-10 shrink-0 rounded-lg border border-border1"
+      />
 
-      {/* 챔피언 정보 */}
-      <div className="ml-1 w-20 text-left whitespace-nowrap text-xs sm:text-sm">{championName}</div>
+      {/* 이름 + 판수 */}
+      <div className="flex-1 min-w-0">
+        <div className="text-sm text-primary1 truncate">{championName}</div>
+        <div className="text-[11px] text-primary2 tabular-nums">{games}판</div>
+      </div>
 
       {/* KDA */}
-      <div className={`ml-2 w-[72px] text-xs sm:text-sm ${getKdaColor(kda)} whitespace-nowrap`}>
-        {kda} KDA
-      </div>
+      <div className={`shrink-0 text-xs tabular-nums ${getKdaColor(kda)}`}>{kda} KDA</div>
 
-      {/* 승률 및 게임 수 */}
-      <div className="flex flex-col ml-6 text-center whitespace-nowrap text-xs sm:text-sm">
-        <div className={`${getWinRateColor(winRate)}`}>{winRate}%</div>
-        <div className="text-gray font-xs">{games} 게임</div>
+      {/* 승률 */}
+      <div
+        className={`w-11 shrink-0 text-right text-[13px] font-bold tabular-nums ${getWinRateColor(winRate)}`}
+      >
+        {winRate}%
       </div>
     </div>
   );

--- a/src/features/matchHistory/TeamworkStats.tsx
+++ b/src/features/matchHistory/TeamworkStats.tsx
@@ -92,7 +92,7 @@ const TeamworkStats = ({ synergyData }: Props) => {
               onClick={() => handleClick(synergy.riotName, synergy.riotNameTag)}
               style={isNew ? { animationDelay: `${(i - prevCount) * 60}ms` } : undefined}
               className={`bg-darkBg1 rounded-lg border border-cardBorder px-3 py-2.5 flex items-center gap-3 hover:bg-grayHover transition-colors text-left w-full ${
-                isNew ? "animate-fadeUp" : ""
+                isNew ? "motion-safe:animate-fadeUp" : ""
               }`}
             >
               {/* 순위 */}

--- a/src/features/matchHistory/TeamworkStats.tsx
+++ b/src/features/matchHistory/TeamworkStats.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/router";
 import { SynergyStats } from "@/data/types/record";
-import { useState, useMemo } from "react";
+import { useState, useMemo, useRef, useEffect } from "react";
 import { getWinRateColor } from "@/utils/statColors";
 
 interface Props {
@@ -48,6 +48,13 @@ const TeamworkStats = ({ synergyData }: Props) => {
   const displayedData = sortedData.slice(0, displayCount);
   const hasMore = sortedData.length > displayCount && displayCount < 10;
 
+  // 이전 렌더의 개수를 기억해 "더보기로 새로 붙은 항목"만 순차 등장시킴
+  const prevCountRef = useRef(displayedData.length);
+  const prevCount = prevCountRef.current;
+  useEffect(() => {
+    prevCountRef.current = displayedData.length;
+  }, [displayedData.length]);
+
   return (
     <div className="flex flex-col gap-2 w-full min-w-0">
       {/* 정렬 토글 */}
@@ -76,38 +83,46 @@ const TeamworkStats = ({ synergyData }: Props) => {
 
       {/* 시너지 목록 */}
       <div className="flex flex-col gap-1.5 w-full min-w-0">
-        {displayedData.map((synergy, i) => (
-          <button
-            key={`${synergy.riotName}-${synergy.riotNameTag}`}
-            type="button"
-            onClick={() => handleClick(synergy.riotName, synergy.riotNameTag)}
-            className="bg-darkBg1 rounded-lg border border-cardBorder px-3 py-2.5 flex items-center gap-3 hover:bg-grayHover transition-colors text-left w-full"
-          >
-            {/* 순위 */}
-            <div className="w-5 shrink-0 text-center text-sm font-bold text-primary2 tabular-nums">
-              {i + 1}
-            </div>
+        {displayedData.map((synergy, i) => {
+          const isNew = i >= prevCount;
+          return (
+            <button
+              key={`${synergy.riotName}-${synergy.riotNameTag}`}
+              type="button"
+              onClick={() => handleClick(synergy.riotName, synergy.riotNameTag)}
+              style={isNew ? { animationDelay: `${(i - prevCount) * 60}ms` } : undefined}
+              className={`bg-darkBg1 rounded-lg border border-cardBorder px-3 py-2.5 flex items-center gap-3 hover:bg-grayHover transition-colors text-left w-full ${
+                isNew ? "animate-fadeUp" : ""
+              }`}
+            >
+              {/* 순위 */}
+              <div className="w-5 shrink-0 text-center text-sm font-bold text-primary2 tabular-nums">
+                {i + 1}
+              </div>
 
-            {/* 닉네임 + 전적 */}
-            <div className="flex-1 min-w-0">
-              <div className="text-sm truncate">
-                <span className="text-primary1">{synergy.riotName}</span>
-                <span className="text-[11px] text-primary3"> #{synergy.riotNameTag}</span>
+              {/* 닉네임 + 전적 */}
+              <div className="flex-1 min-w-0">
+                <div className="text-sm truncate">
+                  <span className="text-primary1">{synergy.riotName}</span>
+                  <span className="text-[11px] text-primary3"> #{synergy.riotNameTag}</span>
+                </div>
+                <div className="text-[11px] text-primary2 mt-0.5 tabular-nums">
+                  {synergy.win}승 {synergy.lose}패 · {synergy.totalCount}판
+                </div>
               </div>
-              <div className="text-[11px] text-primary2 mt-0.5 tabular-nums">
-                {synergy.win}승 {synergy.lose}패 · {synergy.totalCount}판
-              </div>
-            </div>
 
-            {/* 함께 승률 */}
-            <div className="shrink-0 text-right">
-              <div className={`text-sm font-bold tabular-nums ${getWinRateColor(synergy.winRate)}`}>
-                {synergy.winRate}%
+              {/* 함께 승률 */}
+              <div className="shrink-0 text-right">
+                <div
+                  className={`text-sm font-bold tabular-nums ${getWinRateColor(synergy.winRate)}`}
+                >
+                  {synergy.winRate}%
+                </div>
+                <div className="text-[10px] text-primary3">함께 승률</div>
               </div>
-              <div className="text-[10px] text-primary3">함께 승률</div>
-            </div>
-          </button>
-        ))}
+            </button>
+          );
+        })}
       </div>
 
       {/* 더보기 버튼 */}

--- a/src/features/matchHistory/TeamworkStats.tsx
+++ b/src/features/matchHistory/TeamworkStats.tsx
@@ -11,7 +11,7 @@ type SortType = "winRate" | "gameCount";
 
 const TeamworkStats = ({ synergyData }: Props) => {
   const router = useRouter();
-  const [sortType, setSortType] = useState<SortType>("winRate");
+  const [sortType, setSortType] = useState<SortType>("gameCount");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
   const [displayCount, setDisplayCount] = useState(5);
 

--- a/src/features/matchHistory/TeamworkStats.tsx
+++ b/src/features/matchHistory/TeamworkStats.tsx
@@ -48,7 +48,6 @@ const TeamworkStats = ({ synergyData }: Props) => {
   const displayedData = sortedData.slice(0, displayCount);
   const hasMore = sortedData.length > displayCount && displayCount < 10;
 
-  // 이전 렌더의 개수를 기억해 "더보기로 새로 붙은 항목"만 순차 등장시킴
   const prevCountRef = useRef(displayedData.length);
   const prevCount = prevCountRef.current;
   useEffect(() => {

--- a/src/features/matchHistory/TeamworkStats.tsx
+++ b/src/features/matchHistory/TeamworkStats.tsx
@@ -101,9 +101,7 @@ const TeamworkStats = ({ synergyData }: Props) => {
 
             {/* 함께 승률 */}
             <div className="shrink-0 text-right">
-              <div
-                className={`text-base font-bold tabular-nums ${getWinRateColor(synergy.winRate)}`}
-              >
+              <div className={`text-sm font-bold tabular-nums ${getWinRateColor(synergy.winRate)}`}>
                 {synergy.winRate}%
               </div>
               <div className="text-[10px] text-primary3">함께 승률</div>

--- a/src/features/matchHistory/TeamworkStats.tsx
+++ b/src/features/matchHistory/TeamworkStats.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from "next/router";
 import { SynergyStats } from "@/data/types/record";
 import { useState, useMemo } from "react";
+import { getWinRateColor } from "@/utils/statColors";
 
 interface Props {
   synergyData: SynergyStats[];
@@ -49,14 +50,15 @@ const TeamworkStats = ({ synergyData }: Props) => {
 
   return (
     <div className="flex flex-col gap-2 w-full min-w-0">
-      {/* 열 제목 헤더 */}
-      <div className="flex items-center gap-2 sm:gap-4 px-2 sm:px-3 py-1 text-xs font-medium text-primary2">
-        <div className="flex-1 min-w-0" />
+      {/* 정렬 토글 */}
+      <div className="flex items-center justify-end gap-3 px-1 text-xs">
         <button
           type="button"
           onClick={() => handleSort("gameCount")}
-          className={`w-24 sm:w-28 text-center shrink-0 transition-colors ${
-            sortType === "gameCount" ? "text-primary1" : "hover:text-primary1"
+          className={`transition-colors ${
+            sortType === "gameCount"
+              ? "text-primary1 font-bold"
+              : "text-primary2 hover:text-primary1"
           }`}
         >
           판수{getSortIndicator("gameCount")}
@@ -64,40 +66,47 @@ const TeamworkStats = ({ synergyData }: Props) => {
         <button
           type="button"
           onClick={() => handleSort("winRate")}
-          className={`w-14 sm:w-20 text-center shrink-0 transition-colors ${
-            sortType === "winRate" ? "text-primary1" : "hover:text-primary1"
+          className={`transition-colors ${
+            sortType === "winRate" ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
           }`}
         >
           승률{getSortIndicator("winRate")}
         </button>
       </div>
 
-      {/* 데이터 목록 */}
-      <div className="flex flex-col gap-1 sm:gap-2 w-full min-w-0">
-        {displayedData.map((synergy) => (
+      {/* 시너지 목록 */}
+      <div className="flex flex-col gap-1.5 w-full min-w-0">
+        {displayedData.map((synergy, i) => (
           <button
             key={`${synergy.riotName}-${synergy.riotNameTag}`}
             type="button"
             onClick={() => handleClick(synergy.riotName, synergy.riotNameTag)}
-            className="bg-darkBg1 rounded border border-border2 p-2 sm:p-3 flex items-center gap-2 sm:gap-4 hover:bg-grayHover transition-colors text-left w-full"
+            className="bg-darkBg1 rounded-lg border border-cardBorder px-3 py-2.5 flex items-center gap-3 hover:bg-grayHover transition-colors text-left w-full"
           >
-            {/* 닉네임 */}
-            <div className="flex-1 min-w-0">
-              <div className="text-xs sm:text-sm text-primary1 truncate">{synergy.riotName}</div>
-              <div className="text-xs text-primary2">#{synergy.riotNameTag}</div>
+            {/* 순위 */}
+            <div className="w-5 shrink-0 text-center text-sm font-bold text-primary2 tabular-nums">
+              {i + 1}
             </div>
 
-            {/* 판수 */}
-            <div className="w-24 sm:w-28 text-center shrink-0">
-              <div className="text-xs sm:text-sm text-primary1">{synergy.totalCount}전</div>
-              <div className="text-xs text-primary2 mt-0.5">
-                {synergy.win}승 {synergy.lose}패
+            {/* 닉네임 + 전적 */}
+            <div className="flex-1 min-w-0">
+              <div className="text-sm truncate">
+                <span className="text-primary1">{synergy.riotName}</span>
+                <span className="text-[11px] text-primary3"> #{synergy.riotNameTag}</span>
+              </div>
+              <div className="text-[11px] text-primary2 mt-0.5 tabular-nums">
+                {synergy.win}승 {synergy.lose}패 · {synergy.totalCount}판
               </div>
             </div>
 
-            {/* 승률 */}
-            <div className="w-14 sm:w-20 text-center shrink-0">
-              <div className="text-xs sm:text-sm text-primary1">{synergy.winRate}%</div>
+            {/* 함께 승률 */}
+            <div className="shrink-0 text-right">
+              <div
+                className={`text-base font-bold tabular-nums ${getWinRateColor(synergy.winRate)}`}
+              >
+                {synergy.winRate}%
+              </div>
+              <div className="text-[10px] text-primary3">함께 승률</div>
             </div>
           </button>
         ))}

--- a/src/features/matchHistory/UserStatsOverview.tsx
+++ b/src/features/matchHistory/UserStatsOverview.tsx
@@ -60,7 +60,7 @@ const UserStatsOverview = ({
 
       {/* 유저 정보 */}
       <div className="flex flex-col p-4 gap-3 flex-1">
-        <div className="text-3xl md:text-4xl font-bold text-white">
+        <div className="text-3xl md:text-4xl font-bold text-white line-clamp-2 break-all">
           {riotName} <span className="font-normal text-gray">#{riotTag}</span>
         </div>
 

--- a/src/features/matchHistory/UserStatsOverview.tsx
+++ b/src/features/matchHistory/UserStatsOverview.tsx
@@ -1,6 +1,5 @@
 import Image, { StaticImageData } from "next/image";
 import { useState } from "react";
-import { MdRefresh } from "react-icons/md";
 import LaneTopLogo from "@/assets/images/laneTop.png";
 import LaneJungleLogo from "@/assets/images/laneJungle.png";
 import LaneMidLogo from "@/assets/images/laneMid.png";
@@ -62,7 +61,7 @@ const UserStatsOverview = ({
       {/* 유저 정보 */}
       <div className="flex flex-col p-4 gap-3 flex-1">
         <div className="text-3xl md:text-4xl font-bold text-white">
-          {riotName} <span className="font-medium text-gray">#{riotTag}</span>
+          {riotName} <span className="font-normal text-gray">#{riotTag}</span>
         </div>
 
         {totalData && (
@@ -97,12 +96,23 @@ const UserStatsOverview = ({
             type="button"
             onClick={handleRefreshClick}
             disabled={isRefreshing}
-            className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${
-              isRefreshing ? "bg-white text-darkBg2" : "bg-primary1 text-darkBg2 hover:bg-primary2"
-            } disabled:cursor-not-allowed`}
+            className="flex items-center gap-2 px-4 py-2 rounded-lg border border-border2 bg-transparent text-primary1 hover:bg-grayHover transition-colors disabled:cursor-not-allowed disabled:opacity-60"
           >
-            <MdRefresh className={`text-xl ${isRefreshing ? "animate-spin" : ""}`} />
-            <span className="font-medium">{isRefreshing ? "갱신중" : "새로고침"}</span>
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={1.75}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className={`w-4 h-4 ${isRefreshing ? "animate-spin" : ""}`}
+              aria-hidden="true"
+            >
+              <polyline points="23 4 23 10 17 10" />
+              <polyline points="1 20 1 14 7 14" />
+              <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+            </svg>
+            <span className="font-normal">{isRefreshing ? "갱신중" : "새로고침"}</span>
           </button>
         </div>
       )}

--- a/src/features/statistics/ChampionRankHeader.tsx
+++ b/src/features/statistics/ChampionRankHeader.tsx
@@ -23,7 +23,7 @@ const ChampionRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => 
     <>
       {/* 모바일 정렬 (열제목 스타일 — 각 열 중앙 정렬) */}
       <div
-        className={`flex md:hidden items-center gap-1.5 sm:gap-3.5 px-2.5 sm:px-3.5 pb-1.5 ${
+        className={`flex md:hidden items-center gap-1.5 sm:gap-3.5 px-3 sm:px-3.5 pb-1.5 ${
           className || ""
         }`}
       >
@@ -34,7 +34,7 @@ const ChampionRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => 
         <button
           type="button"
           onClick={() => onSort("kda")}
-          className={sortClass("kda", "w-11 sm:w-16")}
+          className={sortClass("kda", "w-12 sm:w-16")}
         >
           KDA{getSortIndicator("kda")}
         </button>
@@ -48,7 +48,7 @@ const ChampionRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => 
         <button
           type="button"
           onClick={() => onSort("winRate")}
-          className={sortClass("winRate", "w-11 sm:w-14")}
+          className={sortClass("winRate", "w-14 sm:w-16")}
         >
           승률{getSortIndicator("winRate")}
         </button>
@@ -85,7 +85,7 @@ const ChampionRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => 
         <button
           type="button"
           onClick={() => onSort("winRate")}
-          className={sortClass("winRate", "w-14")}
+          className={sortClass("winRate", "w-16")}
         >
           승률{getSortIndicator("winRate")}
         </button>

--- a/src/features/statistics/ChampionRankHeader.tsx
+++ b/src/features/statistics/ChampionRankHeader.tsx
@@ -14,28 +14,34 @@ const ChampionRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => 
     return sortOrder === "asc" ? " ▲" : " ▼";
   };
 
-  const mobileSortClass = (column: SortBy) =>
-    `text-[13px] transition-colors cursor-pointer ${
+  const mobileSortClass = (column: SortBy, width: string) =>
+    `${width} shrink-0 text-center text-[13px] transition-colors cursor-pointer ${
       sortBy === column ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
     }`;
 
   return (
     <>
-      {/* 모바일 정렬 (열제목 스타일) */}
+      {/* 모바일 정렬 (열제목 스타일 — 각 열 중앙 정렬) */}
       <div
-        className={`flex md:hidden items-center justify-end gap-4 px-1 pb-1.5 ${className || ""}`}
+        className={`flex md:hidden items-center gap-2.5 sm:gap-3.5 px-3 sm:px-3.5 pb-1.5 ${
+          className || ""
+        }`}
       >
+        {/* 랭크 + 아이콘 + 챔피언 (자리) */}
+        <div className="flex-1 min-w-0" />
+        {/* 라인 (자리) */}
+        <div className="w-9 shrink-0" />
         <button
           type="button"
           onClick={() => onSort("totalGames")}
-          className={mobileSortClass("totalGames")}
+          className={mobileSortClass("totalGames", "w-14 sm:w-16")}
         >
           판수{getSortIndicator("totalGames")}
         </button>
         <button
           type="button"
           onClick={() => onSort("winRate")}
-          className={mobileSortClass("winRate")}
+          className={mobileSortClass("winRate", "w-12 sm:w-14")}
         >
           승률{getSortIndicator("winRate")}
         </button>

--- a/src/features/statistics/ChampionRankHeader.tsx
+++ b/src/features/statistics/ChampionRankHeader.tsx
@@ -1,4 +1,4 @@
-type SortBy = "totalGames" | "winRate";
+type SortBy = "totalGames" | "winRate" | "kda";
 type SortOrder = "asc" | "desc";
 
 interface Props {
@@ -14,7 +14,7 @@ const ChampionRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => 
     return sortOrder === "asc" ? " ▲" : " ▼";
   };
 
-  const mobileSortClass = (column: SortBy, width: string) =>
+  const sortClass = (column: SortBy, width: string) =>
     `${width} shrink-0 text-center text-[13px] transition-colors cursor-pointer ${
       sortBy === column ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
     }`;
@@ -23,25 +23,32 @@ const ChampionRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => 
     <>
       {/* 모바일 정렬 (열제목 스타일 — 각 열 중앙 정렬) */}
       <div
-        className={`flex md:hidden items-center gap-2.5 sm:gap-3.5 px-3 sm:px-3.5 pb-1.5 ${
+        className={`flex md:hidden items-center gap-1.5 sm:gap-3.5 px-2.5 sm:px-3.5 pb-1.5 ${
           className || ""
         }`}
       >
         {/* 랭크 + 아이콘 + 챔피언 (자리) */}
         <div className="flex-1 min-w-0" />
         {/* 라인 (자리) */}
-        <div className="w-9 shrink-0" />
+        <div className="w-8 sm:w-9 shrink-0" />
+        <button
+          type="button"
+          onClick={() => onSort("kda")}
+          className={sortClass("kda", "w-11 sm:w-16")}
+        >
+          KDA{getSortIndicator("kda")}
+        </button>
         <button
           type="button"
           onClick={() => onSort("totalGames")}
-          className={mobileSortClass("totalGames", "w-14 sm:w-16")}
+          className={sortClass("totalGames", "w-12 sm:w-16")}
         >
           판수{getSortIndicator("totalGames")}
         </button>
         <button
           type="button"
           onClick={() => onSort("winRate")}
-          className={mobileSortClass("winRate", "w-12 sm:w-14")}
+          className={sortClass("winRate", "w-11 sm:w-14")}
         >
           승률{getSortIndicator("winRate")}
         </button>
@@ -60,15 +67,16 @@ const ChampionRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => 
         {/* 라인 (자리) */}
         <div className="w-9 shrink-0" />
 
+        {/* KDA 정렬 */}
+        <button type="button" onClick={() => onSort("kda")} className={sortClass("kda", "w-16")}>
+          KDA{getSortIndicator("kda")}
+        </button>
+
         {/* 판수 정렬 */}
         <button
           type="button"
           onClick={() => onSort("totalGames")}
-          className={`w-14 sm:w-16 shrink-0 text-center text-[13px] transition-colors cursor-pointer ${
-            sortBy === "totalGames"
-              ? "text-primary1 font-bold"
-              : "text-primary2 hover:text-primary1"
-          }`}
+          className={sortClass("totalGames", "w-16")}
         >
           판수{getSortIndicator("totalGames")}
         </button>
@@ -77,9 +85,7 @@ const ChampionRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => 
         <button
           type="button"
           onClick={() => onSort("winRate")}
-          className={`w-12 sm:w-14 shrink-0 text-center text-[13px] transition-colors cursor-pointer ${
-            sortBy === "winRate" ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
-          }`}
+          className={sortClass("winRate", "w-14")}
         >
           승률{getSortIndicator("winRate")}
         </button>

--- a/src/features/statistics/ChampionRankHeader.tsx
+++ b/src/features/statistics/ChampionRankHeader.tsx
@@ -15,38 +15,40 @@ const ChampionRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => 
   };
 
   return (
-    <div className={`hidden md:flex items-center gap-3 px-3 py-2 ${className || ""}`}>
-      {/* 랭크 */}
-      <div className="flex-shrink-0 w-8 text-center" />
+    <div className={`hidden md:flex items-center gap-3.5 px-3.5 py-2 ${className || ""}`}>
+      {/* 랭크 (자리) */}
+      <div className="w-5 shrink-0" />
 
-      {/* 챔피언 아이콘 (빈 공간) */}
-      <div className="flex-shrink-0 w-12" />
+      {/* 챔피언 아이콘 (자리) */}
+      <div className="w-11 shrink-0" />
 
-      {/* 챔피언 이름 */}
-      <div className="flex-1 min-w-0" />
+      {/* 챔피언 */}
+      <div className="flex-1 min-w-0 text-[13px] text-primary2">챔피언</div>
 
-      {/* 라인 */}
-      <div className="flex-shrink-0 w-12 text-center" />
+      {/* 라인 (자리) */}
+      <div className="w-9 shrink-0" />
 
-      {/* 승률 */}
-      <div className="flex-shrink-0 w-20 text-center">
+      {/* 승률 / 게임 수 정렬 */}
+      <div className="w-[88px] shrink-0 flex items-center justify-center gap-2 text-[13px]">
         <button
           type="button"
           onClick={() => onSort("winRate")}
-          className="text-sm font-medium text-primary2 hover:text-primary1 transition-colors cursor-pointer"
+          className={`transition-colors cursor-pointer ${
+            sortBy === "winRate" ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
+          }`}
         >
           승률{getSortIndicator("winRate")}
         </button>
-      </div>
-
-      {/* 게임 수 */}
-      <div className="flex-shrink-0 w-20 text-center">
         <button
           type="button"
           onClick={() => onSort("totalGames")}
-          className="text-sm font-medium text-primary2 hover:text-primary1 transition-colors cursor-pointer"
+          className={`transition-colors cursor-pointer ${
+            sortBy === "totalGames"
+              ? "text-primary1 font-bold"
+              : "text-primary2 hover:text-primary1"
+          }`}
         >
-          게임 수{getSortIndicator("totalGames")}
+          게임{getSortIndicator("totalGames")}
         </button>
       </div>
     </div>

--- a/src/features/statistics/ChampionRankHeader.tsx
+++ b/src/features/statistics/ChampionRankHeader.tsx
@@ -14,42 +14,72 @@ const ChampionRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => 
     return sortOrder === "asc" ? " ▲" : " ▼";
   };
 
+  const mobileSortClass = (column: SortBy) =>
+    `px-2.5 py-1 rounded-md border text-[12px] transition-colors cursor-pointer ${
+      sortBy === column
+        ? "border-primary2 text-primary1 font-bold bg-darkBg2"
+        : "border-cardBorder text-primary2 hover:text-primary1"
+    }`;
+
   return (
-    <div className={`hidden md:flex items-center gap-3.5 px-3.5 py-2 ${className || ""}`}>
-      {/* 랭크 (자리) */}
-      <div className="w-5 shrink-0" />
+    <>
+      {/* 모바일 정렬 바 */}
+      <div className={`flex md:hidden items-center justify-end gap-2 px-1 pb-1 ${className || ""}`}>
+        <span className="text-[12px] text-primary2">정렬</span>
+        <button
+          type="button"
+          onClick={() => onSort("totalGames")}
+          className={mobileSortClass("totalGames")}
+        >
+          판수{getSortIndicator("totalGames")}
+        </button>
+        <button
+          type="button"
+          onClick={() => onSort("winRate")}
+          className={mobileSortClass("winRate")}
+        >
+          승률{getSortIndicator("winRate")}
+        </button>
+      </div>
 
-      {/* 챔피언 아이콘 (자리) */}
-      <div className="w-11 shrink-0" />
+      <div className={`hidden md:flex items-center gap-3.5 px-3.5 py-2 ${className || ""}`}>
+        {/* 랭크 (자리) */}
+        <div className="w-5 shrink-0" />
 
-      {/* 챔피언 */}
-      <div className="flex-1 min-w-0 text-[13px] text-primary2">챔피언</div>
+        {/* 챔피언 아이콘 (자리) */}
+        <div className="w-11 shrink-0" />
 
-      {/* 라인 (자리) */}
-      <div className="w-9 shrink-0" />
+        {/* 챔피언 */}
+        <div className="flex-1 min-w-0 text-[13px] text-primary2">챔피언</div>
 
-      {/* 판수 정렬 */}
-      <button
-        type="button"
-        onClick={() => onSort("totalGames")}
-        className={`w-14 sm:w-16 shrink-0 text-center text-[13px] transition-colors cursor-pointer ${
-          sortBy === "totalGames" ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
-        }`}
-      >
-        판수{getSortIndicator("totalGames")}
-      </button>
+        {/* 라인 (자리) */}
+        <div className="w-9 shrink-0" />
 
-      {/* 승률 정렬 */}
-      <button
-        type="button"
-        onClick={() => onSort("winRate")}
-        className={`w-12 sm:w-14 shrink-0 text-center text-[13px] transition-colors cursor-pointer ${
-          sortBy === "winRate" ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
-        }`}
-      >
-        승률{getSortIndicator("winRate")}
-      </button>
-    </div>
+        {/* 판수 정렬 */}
+        <button
+          type="button"
+          onClick={() => onSort("totalGames")}
+          className={`w-14 sm:w-16 shrink-0 text-center text-[13px] transition-colors cursor-pointer ${
+            sortBy === "totalGames"
+              ? "text-primary1 font-bold"
+              : "text-primary2 hover:text-primary1"
+          }`}
+        >
+          판수{getSortIndicator("totalGames")}
+        </button>
+
+        {/* 승률 정렬 */}
+        <button
+          type="button"
+          onClick={() => onSort("winRate")}
+          className={`w-12 sm:w-14 shrink-0 text-center text-[13px] transition-colors cursor-pointer ${
+            sortBy === "winRate" ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
+          }`}
+        >
+          승률{getSortIndicator("winRate")}
+        </button>
+      </div>
+    </>
   );
 };
 

--- a/src/features/statistics/ChampionRankHeader.tsx
+++ b/src/features/statistics/ChampionRankHeader.tsx
@@ -28,29 +28,27 @@ const ChampionRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => 
       {/* 라인 (자리) */}
       <div className="w-9 shrink-0" />
 
-      {/* 승률 / 게임 수 정렬 */}
-      <div className="w-[88px] shrink-0 flex items-center justify-center gap-2 text-[13px]">
-        <button
-          type="button"
-          onClick={() => onSort("winRate")}
-          className={`transition-colors cursor-pointer ${
-            sortBy === "winRate" ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
-          }`}
-        >
-          승률{getSortIndicator("winRate")}
-        </button>
-        <button
-          type="button"
-          onClick={() => onSort("totalGames")}
-          className={`transition-colors cursor-pointer ${
-            sortBy === "totalGames"
-              ? "text-primary1 font-bold"
-              : "text-primary2 hover:text-primary1"
-          }`}
-        >
-          게임{getSortIndicator("totalGames")}
-        </button>
-      </div>
+      {/* 판수 정렬 */}
+      <button
+        type="button"
+        onClick={() => onSort("totalGames")}
+        className={`w-14 sm:w-16 shrink-0 text-center text-[13px] transition-colors cursor-pointer ${
+          sortBy === "totalGames" ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
+        }`}
+      >
+        판수{getSortIndicator("totalGames")}
+      </button>
+
+      {/* 승률 정렬 */}
+      <button
+        type="button"
+        onClick={() => onSort("winRate")}
+        className={`w-12 sm:w-14 shrink-0 text-center text-[13px] transition-colors cursor-pointer ${
+          sortBy === "winRate" ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
+        }`}
+      >
+        승률{getSortIndicator("winRate")}
+      </button>
     </div>
   );
 };

--- a/src/features/statistics/ChampionRankHeader.tsx
+++ b/src/features/statistics/ChampionRankHeader.tsx
@@ -15,17 +15,16 @@ const ChampionRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => 
   };
 
   const mobileSortClass = (column: SortBy) =>
-    `px-2.5 py-1 rounded-md border text-[12px] transition-colors cursor-pointer ${
-      sortBy === column
-        ? "border-primary2 text-primary1 font-bold bg-darkBg2"
-        : "border-cardBorder text-primary2 hover:text-primary1"
+    `text-[13px] transition-colors cursor-pointer ${
+      sortBy === column ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
     }`;
 
   return (
     <>
-      {/* 모바일 정렬 바 */}
-      <div className={`flex md:hidden items-center justify-end gap-2 px-1 pb-1 ${className || ""}`}>
-        <span className="text-[12px] text-primary2">정렬</span>
+      {/* 모바일 정렬 (열제목 스타일) */}
+      <div
+        className={`flex md:hidden items-center justify-end gap-4 px-1 pb-1.5 ${className || ""}`}
+      >
         <button
           type="button"
           onClick={() => onSort("totalGames")}

--- a/src/features/statistics/ChampionRankItem.tsx
+++ b/src/features/statistics/ChampionRankItem.tsx
@@ -66,7 +66,7 @@ const ChampionRankItem = ({
           <span
             title={tier === 1 ? "1티어" : "5티어"}
             aria-label={tier === 1 ? "1티어" : "5티어"}
-            className="absolute left-1/2 top-full -translate-x-1/2 -translate-y-1/2 grid place-items-center w-[18px] h-[18px] rounded-full bg-darkBg2 border border-cardBorder text-[11px] leading-none"
+            className="absolute -bottom-2 -right-2 grid place-items-center w-6 h-6 rounded-full bg-darkBg2 border border-cardBorder text-[15px] leading-none shadow-md"
           >
             {tier === 1 ? "👍" : "💩"}
           </span>

--- a/src/features/statistics/ChampionRankItem.tsx
+++ b/src/features/statistics/ChampionRankItem.tsx
@@ -43,7 +43,7 @@ const ChampionRankItem = ({
 }: Props) => {
   return (
     <div
-      className={`bg-darkBg2 rounded-md border border-cardBorder px-2.5 sm:px-3.5 py-[11px] flex items-center gap-1.5 sm:gap-3.5 ${
+      className={`bg-darkBg2 rounded-md border border-cardBorder px-3 sm:px-3.5 py-[11px] flex items-center gap-1.5 sm:gap-3.5 ${
         className || ""
       }`}
     >
@@ -95,22 +95,24 @@ const ChampionRankItem = ({
       </div>
 
       {/* KDA */}
-      <div className="shrink-0 w-11 sm:w-16 text-center">
+      <div className="shrink-0 w-12 sm:w-16 text-center">
         <div className={`text-[15px] font-bold tabular-nums ${getKdaColor(kda)}`}>{kda}</div>
-        <div className="text-[11px] text-primary2">KDA</div>
       </div>
 
       {/* 판수 */}
       <div className="shrink-0 w-12 sm:w-16 text-center">
         <div className="text-[15px] font-bold text-primary1 tabular-nums">{gameCount}</div>
-        <div className="text-[11px] text-primary2">게임</div>
       </div>
 
       {/* 승률 */}
-      <div className="shrink-0 w-11 sm:w-14 text-center">
-        <div className={`text-[15px] font-bold tabular-nums ${getWinRateColor(winRate)}`}>
+      <div className="shrink-0 w-14 sm:w-16 flex justify-center">
+        <span
+          className={`inline-flex items-center rounded-md px-2 py-[3px] text-sm font-bold tabular-nums ${getWinRateColor(
+            winRate
+          )} ${parseFloat(winRate) > 50 ? "bg-yellow/10" : "bg-primary2/10"}`}
+        >
           {winRate}%
-        </div>
+        </span>
       </div>
     </div>
   );

--- a/src/features/statistics/ChampionRankItem.tsx
+++ b/src/features/statistics/ChampionRankItem.tsx
@@ -6,6 +6,7 @@ import LaneSupportLogo from "@/assets/images/laneSupport.png";
 import LaneBottomLogo from "@/assets/images/laneBottom.png";
 import SpriteImage from "@/components/ui/SpriteImage";
 import { getChampionSprite } from "@/utils/spriteLoader";
+import { getWinRateColor } from "@/utils/statColors";
 
 interface Props {
   rank: number;
@@ -27,6 +28,12 @@ const laneImageMap: Record<string, StaticImageData> = {
   SUP: LaneSupportLogo,
 };
 
+const getTierBgClass = (tierLevel?: number) => {
+  if (tierLevel === 1) return "bg-tierBlue";
+  if (tierLevel === 5) return "bg-tierBrown";
+  return "";
+};
+
 const ChampionRankItem = ({
   rank,
   championName,
@@ -38,128 +45,65 @@ const ChampionRankItem = ({
   isPopular,
   className,
 }: Props) => {
-  const getTierBgClass = (tierLevel?: number) => {
-    switch (tierLevel) {
-      case 1:
-        return "bg-tierBlue";
-      case 5:
-        return "bg-tierBrown";
-      default:
-        return "bg-blue";
-    }
-  };
   return (
-    <div className={`bg-darkBg2 rounded border border-border2 p-3 ${className || ""}`}>
-      {/* 데스크톱 레이아웃 */}
-      <div className="hidden md:flex items-center gap-3">
-        {/* 랭크 */}
-        <div className="flex-shrink-0 w-8 text-center">
-          <span className="text-lg font-bold text-primary1">{rank}</span>
-        </div>
-
-        {/* 챔피언 아이콘 */}
-        <div className="flex-shrink-0 flex items-center justify-center">
-          <SpriteImage
-            spriteData={getChampionSprite(championNameEng)}
-            alt={championName}
-            width={48}
-            height={48}
-            fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/champion/${championNameEng}.png`}
-            className="w-12 h-12"
-          />
-        </div>
-
-        {/* 챔피언 이름 + 태그 */}
-        <div className="flex-1 min-w-0 flex items-center gap-2">
-          <p className="text-base text-primary1 truncate">{championName}</p>
-          {tier && (
-            <span
-              className={`${getTierBgClass(tier)} text-white text-xs px-2 py-1 font-bold flex-shrink-0`}
-            >
-              {tier}
-            </span>
-          )}
-          {isPopular && (
-            <span className="bg-redPopular text-white text-xs px-2 py-1 font-bold flex-shrink-0">
-              인기
-            </span>
-          )}
-        </div>
-
-        {/* 라인 */}
-        <div className="flex-shrink-0 w-12 h-12 flex items-center justify-center">
-          <Image
-            src={laneImageMap[position] || LaneMidLogo}
-            alt={position}
-            width={48}
-            height={48}
-            className="w-full h-full object-contain"
-          />
-        </div>
-
-        {/* 승률 */}
-        <div className="flex-shrink-0 w-20 text-center">
-          <span className="text-sm text-primary1">{winRate}%</span>
-        </div>
-
-        {/* 게임 수 */}
-        <div className="flex-shrink-0 w-20 text-center">
-          <span className="text-sm text-primary2">{gameCount}게임</span>
-        </div>
+    <div
+      className={`bg-darkBg2 rounded-md border border-cardBorder px-3 sm:px-3.5 py-[11px] flex items-center gap-2.5 sm:gap-3.5 ${
+        className || ""
+      }`}
+    >
+      {/* 순위 (균일 — 1위 강조 없음) */}
+      <div className="w-5 shrink-0 text-center text-[15px] font-bold text-primary2 tabular-nums">
+        {rank}
       </div>
 
-      {/* 모바일 레이아웃 */}
-      <div className="flex md:hidden items-center gap-2">
-        {/* 순위 */}
-        <div className="flex-shrink-0 w-6 text-center">
-          <span className="text-base font-bold text-primary1">{rank}</span>
-        </div>
+      {/* 챔피언 아이콘 + 티어 칩 */}
+      <div className="relative shrink-0 w-11 h-11">
+        <SpriteImage
+          spriteData={getChampionSprite(championNameEng)}
+          alt={championName}
+          width={44}
+          height={44}
+          fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/champion/${championNameEng}.png`}
+          className="w-11 h-11 rounded-lg"
+        />
+        {tier && (
+          <span
+            className={`absolute left-1/2 top-full -translate-x-1/2 -translate-y-1/2 ${getTierBgClass(
+              tier
+            )} text-white text-[10px] font-bold leading-none px-1 py-0.5 rounded border border-darkBg2`}
+          >
+            T{tier}
+          </span>
+        )}
+      </div>
 
-        {/* 챔피언 아이콘 */}
-        <div className="flex-shrink-0">
-          <SpriteImage
-            spriteData={getChampionSprite(championNameEng)}
-            alt={championName}
-            width={40}
-            height={40}
-            fallbackSrc={`https://ddragon.leagueoflegends.com/cdn/${process.env.NEXT_PUBLIC_DDRAGON_VERSION}/img/champion/${championNameEng}.png`}
-            className="w-10 h-10"
-          />
-        </div>
+      {/* 챔피언 이름 + 인기 배지 */}
+      <div className="flex-1 min-w-0 flex items-center gap-2">
+        <p className="text-[15px] text-primary1 truncate">{championName}</p>
+        {isPopular && (
+          <span className="shrink-0 bg-redPopular text-white text-[10px] font-bold px-1.5 py-0.5 rounded">
+            인기
+          </span>
+        )}
+      </div>
 
-        {/* 챔피언 이름 + 라인 */}
-        <div className="flex-1 min-w-0 flex items-center gap-2">
-          <p className="text-sm text-primary1 truncate">{championName}</p>
-          {tier && (
-            <span
-              className={`${getTierBgClass(tier)} text-white text-xs px-1.5 py-0.5 font-bold flex-shrink-0`}
-            >
-              {tier}
-            </span>
-          )}
-          {isPopular && (
-            <span className="bg-redPopular text-white text-xs px-1.5 py-0.5 font-bold flex-shrink-0">
-              인기
-            </span>
-          )}
-        </div>
+      {/* 라인 아이콘 36×36 */}
+      <div className="shrink-0 w-9 h-9 flex items-center justify-center">
+        <Image
+          src={laneImageMap[position] || LaneMidLogo}
+          alt={position}
+          width={36}
+          height={36}
+          className="w-full h-full object-contain"
+        />
+      </div>
 
-        {/* 라인 아이콘 */}
-        <div className="flex-shrink-0 w-6 h-6 flex items-center justify-center">
-          <Image
-            src={laneImageMap[position] || LaneMidLogo}
-            alt={position}
-            width={24}
-            height={24}
-            className="w-full h-full object-contain"
-          />
+      {/* 승률 + 게임 수 */}
+      <div className="shrink-0 w-[72px] sm:w-[88px] text-center">
+        <div className={`text-[15px] font-bold tabular-nums ${getWinRateColor(winRate)}`}>
+          {winRate}%
         </div>
-
-        {/* 승률 + 게임 수 */}
-        <div className="flex-shrink-0 text-right">
-          <div className="text-sm text-primary1">{winRate}%</div>
-          <div className="text-xs text-primary2">{gameCount}게임</div>
-        </div>
+        <div className="text-[11px] text-primary2 tabular-nums">{gameCount}게임</div>
       </div>
     </div>
   );

--- a/src/features/statistics/ChampionRankItem.tsx
+++ b/src/features/statistics/ChampionRankItem.tsx
@@ -98,12 +98,17 @@ const ChampionRankItem = ({
         />
       </div>
 
-      {/* 승률 + 게임 수 */}
-      <div className="shrink-0 w-[72px] sm:w-[88px] text-center">
+      {/* 판수 */}
+      <div className="shrink-0 w-14 sm:w-16 text-center">
+        <div className="text-[15px] font-bold text-primary1 tabular-nums">{gameCount}</div>
+        <div className="text-[11px] text-primary2">게임</div>
+      </div>
+
+      {/* 승률 */}
+      <div className="shrink-0 w-12 sm:w-14 text-center">
         <div className={`text-[15px] font-bold tabular-nums ${getWinRateColor(winRate)}`}>
           {winRate}%
         </div>
-        <div className="text-[11px] text-primary2 tabular-nums">{gameCount}게임</div>
       </div>
     </div>
   );

--- a/src/features/statistics/ChampionRankItem.tsx
+++ b/src/features/statistics/ChampionRankItem.tsx
@@ -6,7 +6,7 @@ import LaneSupportLogo from "@/assets/images/laneSupport.png";
 import LaneBottomLogo from "@/assets/images/laneBottom.png";
 import SpriteImage from "@/components/ui/SpriteImage";
 import { getChampionSprite } from "@/utils/spriteLoader";
-import { getWinRateColor } from "@/utils/statColors";
+import { getKdaColor, getWinRateColor } from "@/utils/statColors";
 
 interface Props {
   rank: number;
@@ -14,6 +14,7 @@ interface Props {
   championNameEng: string;
   position: "TOP" | "JUG" | "MID" | "ADC" | "SUP";
   winRate: string;
+  kda: string;
   gameCount: number;
   tier?: 1 | 5;
   isPopular?: boolean;
@@ -28,18 +29,13 @@ const laneImageMap: Record<string, StaticImageData> = {
   SUP: LaneSupportLogo,
 };
 
-const getTierBgClass = (tierLevel?: number) => {
-  if (tierLevel === 1) return "bg-tierBlue";
-  if (tierLevel === 5) return "bg-tierBrown";
-  return "";
-};
-
 const ChampionRankItem = ({
   rank,
   championName,
   championNameEng,
   position,
   winRate,
+  kda,
   gameCount,
   tier,
   isPopular,
@@ -47,7 +43,7 @@ const ChampionRankItem = ({
 }: Props) => {
   return (
     <div
-      className={`bg-darkBg2 rounded-md border border-cardBorder px-3 sm:px-3.5 py-[11px] flex items-center gap-2.5 sm:gap-3.5 ${
+      className={`bg-darkBg2 rounded-md border border-cardBorder px-2.5 sm:px-3.5 py-[11px] flex items-center gap-1.5 sm:gap-3.5 ${
         className || ""
       }`}
     >
@@ -56,7 +52,7 @@ const ChampionRankItem = ({
         {rank}
       </div>
 
-      {/* 챔피언 아이콘 + 티어 칩 */}
+      {/* 챔피언 아이콘 + 티어 배지(👍 / 💩) */}
       <div className="relative shrink-0 w-11 h-11">
         <SpriteImage
           spriteData={getChampionSprite(championNameEng)}
@@ -68,11 +64,11 @@ const ChampionRankItem = ({
         />
         {tier && (
           <span
-            className={`absolute left-1/2 top-full -translate-x-1/2 -translate-y-1/2 ${getTierBgClass(
-              tier
-            )} text-white text-[10px] font-bold leading-none px-1 py-0.5 rounded border border-darkBg2`}
+            title={tier === 1 ? "1티어" : "5티어"}
+            aria-label={tier === 1 ? "1티어" : "5티어"}
+            className="absolute left-1/2 top-full -translate-x-1/2 -translate-y-1/2 grid place-items-center w-[18px] h-[18px] rounded-full bg-darkBg2 border border-cardBorder text-[11px] leading-none"
           >
-            T{tier}
+            {tier === 1 ? "👍" : "💩"}
           </span>
         )}
       </div>
@@ -87,8 +83,8 @@ const ChampionRankItem = ({
         )}
       </div>
 
-      {/* 라인 아이콘 36×36 */}
-      <div className="shrink-0 w-9 h-9 flex items-center justify-center">
+      {/* 라인 아이콘 */}
+      <div className="shrink-0 w-8 sm:w-9 h-9 flex items-center justify-center">
         <Image
           src={laneImageMap[position] || LaneMidLogo}
           alt={position}
@@ -98,14 +94,20 @@ const ChampionRankItem = ({
         />
       </div>
 
+      {/* KDA */}
+      <div className="shrink-0 w-11 sm:w-16 text-center">
+        <div className={`text-[15px] font-bold tabular-nums ${getKdaColor(kda)}`}>{kda}</div>
+        <div className="text-[11px] text-primary2">KDA</div>
+      </div>
+
       {/* 판수 */}
-      <div className="shrink-0 w-14 sm:w-16 text-center">
+      <div className="shrink-0 w-12 sm:w-16 text-center">
         <div className="text-[15px] font-bold text-primary1 tabular-nums">{gameCount}</div>
         <div className="text-[11px] text-primary2">게임</div>
       </div>
 
       {/* 승률 */}
-      <div className="shrink-0 w-12 sm:w-14 text-center">
+      <div className="shrink-0 w-11 sm:w-14 text-center">
         <div className={`text-[15px] font-bold tabular-nums ${getWinRateColor(winRate)}`}>
           {winRate}%
         </div>

--- a/src/features/statistics/ChampionRankItem.tsx
+++ b/src/features/statistics/ChampionRankItem.tsx
@@ -77,7 +77,7 @@ const ChampionRankItem = ({
       <div className="flex-1 min-w-0 flex items-center gap-2">
         <p className="text-[15px] text-primary1 truncate">{championName}</p>
         {isPopular && (
-          <span className="shrink-0 bg-redPopular text-white text-[10px] font-bold px-1.5 py-0.5 rounded">
+          <span className="shrink-0 inline-flex items-center h-[18px] px-1.5 rounded bg-redPopular text-white text-[10px] font-bold leading-none">
             인기
           </span>
         )}

--- a/src/features/statistics/DateRangeFilter.tsx
+++ b/src/features/statistics/DateRangeFilter.tsx
@@ -69,10 +69,10 @@ const DateRangeFilter = ({ onChange, className }: Props) => {
             key={mode}
             type="button"
             onClick={() => handleModeChange(mode)}
-            className={`px-3 py-1.5 rounded-md text-sm font-medium transition-all duration-200 ${
+            className={`px-3 py-1.5 rounded-md text-sm transition-all duration-200 ${
               dateMode === mode
-                ? "bg-primary1 text-darkBg2 shadow"
-                : "text-primary2 hover:text-primary1"
+                ? "bg-blue text-blueText font-bold"
+                : "text-primary2 font-normal hover:text-primary1"
             }`}
           >
             {DATE_LABELS[mode]}

--- a/src/features/statistics/PositionFilter.tsx
+++ b/src/features/statistics/PositionFilter.tsx
@@ -34,10 +34,10 @@ const PositionFilter = ({ selectedPosition, onSelectPosition, className, share }
             key={position.value}
             type="button"
             onClick={() => onSelectPosition(position.value)}
-            className={`flex items-center gap-1.5 sm:gap-2 px-3 sm:px-4 py-1.5 sm:py-2 rounded border transition-colors border-border2 ${
+            className={`flex items-center gap-1.5 sm:gap-2 px-3 sm:px-4 py-1.5 sm:py-2 rounded border transition-colors ${
               isSelected
-                ? "bg-primary1 text-blueDarken"
-                : "bg-darkBg2 text-primary2 hover:bg-grayHover"
+                ? "bg-blue border-blueButton text-blueText font-bold"
+                : "bg-darkBg2 border-border2 text-primary2 hover:bg-grayHover font-normal"
             }`}
           >
             {position.icon && (
@@ -49,11 +49,11 @@ const PositionFilter = ({ selectedPosition, onSelectPosition, className, share }
                 className="w-4 h-4 sm:w-5 sm:h-5 object-contain"
               />
             )}
-            <span className="text-xs sm:text-sm font-medium">{position.label}</span>
+            <span className="text-xs sm:text-sm">{position.label}</span>
             {pct != null && (
               <span
                 className={`text-[10px] font-bold tabular-nums ${
-                  isSelected ? "text-blueDarken" : "text-blueText"
+                  isSelected ? "text-blueText" : "text-primary2"
                 }`}
               >
                 {pct}%

--- a/src/features/statistics/UserRankHeader.tsx
+++ b/src/features/statistics/UserRankHeader.tsx
@@ -1,4 +1,4 @@
-type SortBy = "totalGames" | "winRate";
+type SortBy = "totalGames" | "winRate" | "kda";
 type SortOrder = "asc" | "desc";
 
 interface Props {
@@ -14,7 +14,7 @@ const UserRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => {
     return sortOrder === "asc" ? " ▲" : " ▼";
   };
 
-  const mobileSortClass = (column: SortBy, width: string) =>
+  const sortClass = (column: SortBy, width: string) =>
     `${width} shrink-0 text-center text-[13px] transition-colors cursor-pointer ${
       sortBy === column ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
     }`;
@@ -23,23 +23,26 @@ const UserRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => {
     <>
       {/* 모바일 정렬 (열제목 스타일 — 각 열 중앙 정렬) */}
       <div
-        className={`flex md:hidden items-center gap-2.5 sm:gap-3.5 pl-3 pr-6 sm:pl-3.5 sm:pr-10 pb-1.5 ${
+        className={`flex md:hidden items-center gap-1.5 sm:gap-3.5 pl-3 pr-4 sm:pl-3.5 sm:pr-10 pb-1.5 ${
           className || ""
         }`}
       >
         {/* 순위 + 라인 + 닉네임 (자리) */}
         <div className="flex-1 min-w-0" />
+        <button type="button" onClick={() => onSort("kda")} className={sortClass("kda", "w-12")}>
+          KDA{getSortIndicator("kda")}
+        </button>
         <button
           type="button"
           onClick={() => onSort("totalGames")}
-          className={mobileSortClass("totalGames", "w-28")}
+          className={sortClass("totalGames", "w-24")}
         >
           전적{getSortIndicator("totalGames")}
         </button>
         <button
           type="button"
           onClick={() => onSort("winRate")}
-          className={mobileSortClass("winRate", "w-14")}
+          className={sortClass("winRate", "w-12")}
         >
           승률{getSortIndicator("winRate")}
         </button>
@@ -57,15 +60,16 @@ const UserRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => {
         {/* 닉네임 (자리) */}
         <div className="flex-1 min-w-0" />
 
+        {/* KDA */}
+        <button type="button" onClick={() => onSort("kda")} className={sortClass("kda", "w-16")}>
+          KDA{getSortIndicator("kda")}
+        </button>
+
         {/* 전적 */}
         <button
           type="button"
           onClick={() => onSort("totalGames")}
-          className={`w-40 shrink-0 text-center transition-colors cursor-pointer ${
-            sortBy === "totalGames"
-              ? "text-primary1 font-bold"
-              : "text-primary2 hover:text-primary1"
-          }`}
+          className={sortClass("totalGames", "w-40")}
         >
           전적{getSortIndicator("totalGames")}
         </button>
@@ -74,9 +78,7 @@ const UserRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => {
         <button
           type="button"
           onClick={() => onSort("winRate")}
-          className={`shrink-0 w-[52px] text-center transition-colors cursor-pointer ${
-            sortBy === "winRate" ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
-          }`}
+          className={sortClass("winRate", "w-[52px]")}
         >
           승률{getSortIndicator("winRate")}
         </button>

--- a/src/features/statistics/UserRankHeader.tsx
+++ b/src/features/statistics/UserRankHeader.tsx
@@ -15,42 +15,39 @@ const UserRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => {
   };
 
   return (
-    <div className={`hidden md:flex items-center gap-3 px-3 py-2 ${className || ""}`}>
-      {/* 순위 (빈 공간) */}
-      <div className="flex-shrink-0 w-8 text-center" />
+    <div
+      className={`hidden md:flex items-center gap-3.5 px-3.5 py-2 text-[13px] ${className || ""}`}
+    >
+      {/* 순위 (자리) */}
+      <div className="w-[18px] shrink-0" />
 
-      {/* 라인 (빈 공간) */}
-      <div className="flex-shrink-0 w-10 text-center" />
+      {/* 라인 (자리) */}
+      <div className="w-8 shrink-0" />
 
-      {/* 닉네임 (빈 공간) */}
+      {/* 닉네임 (자리) */}
       <div className="flex-1 min-w-0" />
 
-      {/* KDA */}
-      <div className="flex-shrink-0 w-20 text-center">
-        <span className="text-sm font-medium text-primary2">KDA</span>
-      </div>
-
       {/* 전적 */}
-      <div className="flex-shrink-0 w-32 text-center">
-        <button
-          type="button"
-          onClick={() => onSort("totalGames")}
-          className="text-sm font-medium text-primary2 hover:text-primary1 transition-colors cursor-pointer"
-        >
-          전적{getSortIndicator("totalGames")}
-        </button>
-      </div>
+      <button
+        type="button"
+        onClick={() => onSort("totalGames")}
+        className={`shrink-0 transition-colors cursor-pointer ${
+          sortBy === "totalGames" ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
+        }`}
+      >
+        전적{getSortIndicator("totalGames")}
+      </button>
 
       {/* 승률 */}
-      <div className="flex-shrink-0 w-20 text-center">
-        <button
-          type="button"
-          onClick={() => onSort("winRate")}
-          className="text-sm font-medium text-primary2 hover:text-primary1 transition-colors cursor-pointer"
-        >
-          승률{getSortIndicator("winRate")}
-        </button>
-      </div>
+      <button
+        type="button"
+        onClick={() => onSort("winRate")}
+        className={`shrink-0 w-[52px] text-center transition-colors cursor-pointer ${
+          sortBy === "winRate" ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
+        }`}
+      >
+        승률{getSortIndicator("winRate")}
+      </button>
     </div>
   );
 };

--- a/src/features/statistics/UserRankHeader.tsx
+++ b/src/features/statistics/UserRankHeader.tsx
@@ -31,7 +31,7 @@ const UserRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => {
       <button
         type="button"
         onClick={() => onSort("totalGames")}
-        className={`shrink-0 transition-colors cursor-pointer ${
+        className={`w-40 shrink-0 text-center transition-colors cursor-pointer ${
           sortBy === "totalGames" ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
         }`}
       >

--- a/src/features/statistics/UserRankHeader.tsx
+++ b/src/features/statistics/UserRankHeader.tsx
@@ -15,17 +15,16 @@ const UserRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => {
   };
 
   const mobileSortClass = (column: SortBy) =>
-    `px-2.5 py-1 rounded-md border text-[12px] transition-colors cursor-pointer ${
-      sortBy === column
-        ? "border-primary2 text-primary1 font-bold bg-darkBg2"
-        : "border-cardBorder text-primary2 hover:text-primary1"
+    `text-[13px] transition-colors cursor-pointer ${
+      sortBy === column ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
     }`;
 
   return (
     <>
-      {/* 모바일 정렬 바 */}
-      <div className={`flex md:hidden items-center justify-end gap-2 px-1 pb-1 ${className || ""}`}>
-        <span className="text-[12px] text-primary2">정렬</span>
+      {/* 모바일 정렬 (열제목 스타일) */}
+      <div
+        className={`flex md:hidden items-center justify-end gap-4 px-1 pb-1.5 ${className || ""}`}
+      >
         <button
           type="button"
           onClick={() => onSort("totalGames")}

--- a/src/features/statistics/UserRankHeader.tsx
+++ b/src/features/statistics/UserRankHeader.tsx
@@ -23,39 +23,43 @@ const UserRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => {
     <>
       {/* 모바일 정렬 (열제목 스타일 — 각 열 중앙 정렬) */}
       <div
-        className={`flex md:hidden items-center gap-1.5 sm:gap-3.5 pl-3 pr-4 sm:pl-3.5 sm:pr-10 pb-1.5 ${
+        className={`flex md:hidden items-center gap-1.5 sm:gap-3.5 px-3 sm:px-3.5 pb-1.5 ${
           className || ""
         }`}
       >
         {/* 순위 + 라인 + 닉네임 (자리) */}
         <div className="flex-1 min-w-0" />
-        <button type="button" onClick={() => onSort("kda")} className={sortClass("kda", "w-12")}>
+        <button
+          type="button"
+          onClick={() => onSort("kda")}
+          className={sortClass("kda", "w-12 sm:w-16")}
+        >
           KDA{getSortIndicator("kda")}
         </button>
         <button
           type="button"
           onClick={() => onSort("totalGames")}
-          className={sortClass("totalGames", "w-24")}
+          className={sortClass("totalGames", "w-[92px] sm:w-40")}
         >
           전적{getSortIndicator("totalGames")}
         </button>
         <button
           type="button"
           onClick={() => onSort("winRate")}
-          className={sortClass("winRate", "w-12")}
+          className={sortClass("winRate", "w-14 sm:w-16")}
         >
           승률{getSortIndicator("winRate")}
         </button>
       </div>
 
       <div
-        className={`hidden md:flex items-center gap-3.5 pl-3.5 pr-10 py-2 text-[13px] ${className || ""}`}
+        className={`hidden md:flex items-center gap-3.5 px-3.5 py-2 text-[13px] ${className || ""}`}
       >
         {/* 순위 (자리) */}
-        <div className="w-[18px] shrink-0" />
+        <div className="w-5 shrink-0" />
 
         {/* 라인 (자리) */}
-        <div className="w-8 shrink-0" />
+        <div className="w-9 shrink-0" />
 
         {/* 닉네임 (자리) */}
         <div className="flex-1 min-w-0" />
@@ -78,7 +82,7 @@ const UserRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => {
         <button
           type="button"
           onClick={() => onSort("winRate")}
-          className={sortClass("winRate", "w-[52px]")}
+          className={sortClass("winRate", "w-16")}
         >
           승률{getSortIndicator("winRate")}
         </button>

--- a/src/features/statistics/UserRankHeader.tsx
+++ b/src/features/statistics/UserRankHeader.tsx
@@ -14,41 +14,71 @@ const UserRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => {
     return sortOrder === "asc" ? " ▲" : " ▼";
   };
 
+  const mobileSortClass = (column: SortBy) =>
+    `px-2.5 py-1 rounded-md border text-[12px] transition-colors cursor-pointer ${
+      sortBy === column
+        ? "border-primary2 text-primary1 font-bold bg-darkBg2"
+        : "border-cardBorder text-primary2 hover:text-primary1"
+    }`;
+
   return (
-    <div
-      className={`hidden md:flex items-center gap-3.5 px-3.5 py-2 text-[13px] ${className || ""}`}
-    >
-      {/* 순위 (자리) */}
-      <div className="w-[18px] shrink-0" />
+    <>
+      {/* 모바일 정렬 바 */}
+      <div className={`flex md:hidden items-center justify-end gap-2 px-1 pb-1 ${className || ""}`}>
+        <span className="text-[12px] text-primary2">정렬</span>
+        <button
+          type="button"
+          onClick={() => onSort("totalGames")}
+          className={mobileSortClass("totalGames")}
+        >
+          전적{getSortIndicator("totalGames")}
+        </button>
+        <button
+          type="button"
+          onClick={() => onSort("winRate")}
+          className={mobileSortClass("winRate")}
+        >
+          승률{getSortIndicator("winRate")}
+        </button>
+      </div>
 
-      {/* 라인 (자리) */}
-      <div className="w-8 shrink-0" />
-
-      {/* 닉네임 (자리) */}
-      <div className="flex-1 min-w-0" />
-
-      {/* 전적 */}
-      <button
-        type="button"
-        onClick={() => onSort("totalGames")}
-        className={`w-40 shrink-0 text-center transition-colors cursor-pointer ${
-          sortBy === "totalGames" ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
-        }`}
+      <div
+        className={`hidden md:flex items-center gap-3.5 pl-3.5 pr-10 py-2 text-[13px] ${className || ""}`}
       >
-        전적{getSortIndicator("totalGames")}
-      </button>
+        {/* 순위 (자리) */}
+        <div className="w-[18px] shrink-0" />
 
-      {/* 승률 */}
-      <button
-        type="button"
-        onClick={() => onSort("winRate")}
-        className={`shrink-0 w-[52px] text-center transition-colors cursor-pointer ${
-          sortBy === "winRate" ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
-        }`}
-      >
-        승률{getSortIndicator("winRate")}
-      </button>
-    </div>
+        {/* 라인 (자리) */}
+        <div className="w-8 shrink-0" />
+
+        {/* 닉네임 (자리) */}
+        <div className="flex-1 min-w-0" />
+
+        {/* 전적 */}
+        <button
+          type="button"
+          onClick={() => onSort("totalGames")}
+          className={`w-40 shrink-0 text-center transition-colors cursor-pointer ${
+            sortBy === "totalGames"
+              ? "text-primary1 font-bold"
+              : "text-primary2 hover:text-primary1"
+          }`}
+        >
+          전적{getSortIndicator("totalGames")}
+        </button>
+
+        {/* 승률 */}
+        <button
+          type="button"
+          onClick={() => onSort("winRate")}
+          className={`shrink-0 w-[52px] text-center transition-colors cursor-pointer ${
+            sortBy === "winRate" ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
+          }`}
+        >
+          승률{getSortIndicator("winRate")}
+        </button>
+      </div>
+    </>
   );
 };
 

--- a/src/features/statistics/UserRankHeader.tsx
+++ b/src/features/statistics/UserRankHeader.tsx
@@ -14,28 +14,32 @@ const UserRankHeader = ({ className, sortBy, sortOrder, onSort }: Props) => {
     return sortOrder === "asc" ? " ▲" : " ▼";
   };
 
-  const mobileSortClass = (column: SortBy) =>
-    `text-[13px] transition-colors cursor-pointer ${
+  const mobileSortClass = (column: SortBy, width: string) =>
+    `${width} shrink-0 text-center text-[13px] transition-colors cursor-pointer ${
       sortBy === column ? "text-primary1 font-bold" : "text-primary2 hover:text-primary1"
     }`;
 
   return (
     <>
-      {/* 모바일 정렬 (열제목 스타일) */}
+      {/* 모바일 정렬 (열제목 스타일 — 각 열 중앙 정렬) */}
       <div
-        className={`flex md:hidden items-center justify-end gap-4 px-1 pb-1.5 ${className || ""}`}
+        className={`flex md:hidden items-center gap-2.5 sm:gap-3.5 pl-3 pr-6 sm:pl-3.5 sm:pr-10 pb-1.5 ${
+          className || ""
+        }`}
       >
+        {/* 순위 + 라인 + 닉네임 (자리) */}
+        <div className="flex-1 min-w-0" />
         <button
           type="button"
           onClick={() => onSort("totalGames")}
-          className={mobileSortClass("totalGames")}
+          className={mobileSortClass("totalGames", "w-28")}
         >
           전적{getSortIndicator("totalGames")}
         </button>
         <button
           type="button"
           onClick={() => onSort("winRate")}
-          className={mobileSortClass("winRate")}
+          className={mobileSortClass("winRate", "w-14")}
         >
           승률{getSortIndicator("winRate")}
         </button>

--- a/src/features/statistics/UserRankItem.tsx
+++ b/src/features/statistics/UserRankItem.tsx
@@ -95,12 +95,12 @@ const UserRankItem = ({
       </div>
 
       {/* 전적 (n전 n승 n패) */}
-      <div className="shrink-0 text-right text-[13px] text-primary2 tabular-nums whitespace-nowrap">
+      <div className="w-auto md:w-40 shrink-0 text-right md:text-center text-[13px] text-primary2 tabular-nums whitespace-nowrap">
         {formatNumber(totalGames)}전 {formatNumber(wins)}승 {formatNumber(losses)}패
       </div>
 
       {/* 승률 pill */}
-      <div className="shrink-0">
+      <div className="shrink-0 flex justify-end md:w-[52px] md:justify-center">
         <span
           className={`inline-block rounded-md text-sm font-bold tabular-nums ${getWinRateColor(
             winRate

--- a/src/features/statistics/UserRankItem.tsx
+++ b/src/features/statistics/UserRankItem.tsx
@@ -95,12 +95,12 @@ const UserRankItem = ({
       </div>
 
       {/* 전적 (n전 n승 n패) */}
-      <div className="w-auto md:w-40 shrink-0 text-right md:text-center text-[13px] text-primary2 tabular-nums whitespace-nowrap">
+      <div className="w-28 md:w-40 shrink-0 text-center text-[13px] text-primary2 tabular-nums whitespace-nowrap">
         {formatNumber(totalGames)}전 {formatNumber(wins)}승 {formatNumber(losses)}패
       </div>
 
       {/* 승률 pill */}
-      <div className="shrink-0 flex justify-end md:w-[52px] md:justify-center">
+      <div className="w-14 md:w-[52px] shrink-0 flex justify-center">
         <span
           className={`inline-block rounded-md text-sm font-bold tabular-nums ${getWinRateColor(
             winRate

--- a/src/features/statistics/UserRankItem.tsx
+++ b/src/features/statistics/UserRankItem.tsx
@@ -5,6 +5,7 @@ import LaneJungleLogo from "@/assets/images/laneJungle.png";
 import LaneMidLogo from "@/assets/images/laneMid.png";
 import LaneSupportLogo from "@/assets/images/laneSupport.png";
 import LaneBottomLogo from "@/assets/images/laneBottom.png";
+import { getKdaColor, getWinRateColor } from "@/utils/statColors";
 
 interface Props {
   rank: number;
@@ -45,109 +46,69 @@ const UserRankItem = ({
 }: Props) => {
   const router = useRouter();
 
+  const winRateValue = parseFloat(winRate.replace("%", ""));
+  const pillBg = winRateValue > 50 ? "rgba(255,195,100,0.14)" : "rgba(154,160,168,0.12)";
+
+  const goToSummoner = () => {
+    router.push(`/summoners/${encodeURIComponent(riotName)}/${encodeURIComponent(riotNameTag)}`);
+  };
+
   return (
-    <div className={`bg-darkBg2 rounded border border-border2 p-3 ${className || ""}`}>
-      {/* 데스크톱 레이아웃 */}
-      <div className="hidden md:flex items-center gap-3">
-        {/* 순위 */}
-        <div className="flex-shrink-0 w-8 text-center">
-          <span className="text-lg font-bold text-primary1">{rank}</span>
+    <div
+      className={`bg-darkBg2 rounded-md border border-cardBorder px-3 sm:px-3.5 py-[11px] flex items-center gap-2.5 sm:gap-3.5 ${
+        className || ""
+      }`}
+    >
+      {/* 순위 (균일 — 1위 강조 없음) */}
+      <div className="w-[18px] shrink-0 text-center text-[15px] font-bold text-primary2 tabular-nums">
+        {rank}
+      </div>
+
+      {/* 라인 아이콘 32×32 */}
+      {position && (
+        <div className="shrink-0 w-8 h-8 flex items-center justify-center">
+          <Image
+            src={laneImageMap[position] || LaneMidLogo}
+            alt={position}
+            width={32}
+            height={32}
+            className="w-full h-full object-contain"
+          />
         </div>
+      )}
 
-        {/* 라인 아이콘 */}
-        {position && (
-          <div className="flex-shrink-0 w-12 h-12 flex items-center justify-center">
-            <Image
-              src={laneImageMap[position] || LaneMidLogo}
-              alt={position}
-              width={48}
-              height={48}
-              className="w-full h-full object-contain"
-            />
-          </div>
-        )}
-
-        {/* 닉네임 */}
-        <div className="flex-1 min-w-0 relative group">
-          <button
-            type="button"
-            className="text-base text-primary1 truncate w-full text-left hover:text-primary2 transition-colors"
-            onClick={() => {
-              router.push(
-                `/summoners/${encodeURIComponent(riotName)}/${encodeURIComponent(riotNameTag)}`
-              );
-            }}
-          >
-            {riotName}
-          </button>
-          <div className="absolute bottom-full left-0 mb-2 hidden group-hover:block px-3 py-1 rounded bg-black text-white z-10 whitespace-nowrap">
-            <span>{riotName}</span>
-            <span className="text-primary2"> #{riotNameTag}</span>
-            <div className="absolute top-full left-4 w-0 h-0 border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-black" />
-          </div>
-        </div>
-
-        {/* KDA */}
-        <div className="flex-shrink-0 w-20 text-center">
-          <span className="text-sm text-primary2">{kda}</span>
-        </div>
-
-        {/* 전적 (n전 n승 n패) */}
-        <div className="flex-shrink-0 w-32 text-center">
-          <span className="text-sm text-primary1">
-            {formatNumber(totalGames)}전 {formatNumber(wins)}승 {formatNumber(losses)}패
-          </span>
-        </div>
-
-        {/* 승률 */}
-        <div className="flex-shrink-0 w-20 text-center">
-          <span className="text-sm text-primary1">{winRate}%</span>
+      {/* 닉네임 + KDA */}
+      <div className="flex-1 min-w-0 relative group">
+        <button
+          type="button"
+          className="block text-[15px] text-primary1 truncate w-full text-left hover:text-primary2 transition-colors"
+          onClick={goToSummoner}
+        >
+          {riotName}
+        </button>
+        <div className={`text-[11px] mt-0.5 tabular-nums ${getKdaColor(kda)}`}>KDA {kda}</div>
+        <div className="absolute bottom-full left-0 mb-2 hidden group-hover:block px-3 py-1 rounded bg-black text-white z-10 whitespace-nowrap">
+          <span>{riotName}</span>
+          <span className="text-primary2"> #{riotNameTag}</span>
+          <div className="absolute top-full left-4 w-0 h-0 border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-black" />
         </div>
       </div>
 
-      {/* 모바일 레이아웃 */}
-      <div className="flex md:hidden items-center gap-2">
-        {/* 순위 */}
-        <div className="flex-shrink-0 w-6 text-center">
-          <span className="text-base font-bold text-primary1">{rank}</span>
-        </div>
+      {/* 전적 (n전 n승 n패) */}
+      <div className="shrink-0 text-right text-[13px] text-primary2 tabular-nums whitespace-nowrap">
+        {formatNumber(totalGames)}전 {formatNumber(wins)}승 {formatNumber(losses)}패
+      </div>
 
-        {/* 라인 아이콘 */}
-        {position && (
-          <div className="flex-shrink-0 w-8 h-8 flex items-center justify-center">
-            <Image
-              src={laneImageMap[position] || LaneMidLogo}
-              alt={position}
-              width={32}
-              height={32}
-              className="w-full h-full object-contain"
-            />
-          </div>
-        )}
-
-        {/* 닉네임 + KDA */}
-        <div className="flex-1 min-w-0">
-          <button
-            type="button"
-            className="text-sm text-primary1 truncate w-full text-left hover:text-primary2 transition-colors"
-            onClick={() => {
-              router.push(
-                `/summoners/${encodeURIComponent(riotName)}/${encodeURIComponent(riotNameTag)}`
-              );
-            }}
-          >
-            {riotName}
-          </button>
-          <div className="text-xs text-primary2">{kda}</div>
-        </div>
-
-        {/* 전적 + 승률 */}
-        <div className="flex-shrink-0 text-right">
-          <div className="text-sm text-primary1">
-            {formatNumber(totalGames)}전 {formatNumber(wins)}승 {formatNumber(losses)}패
-          </div>
-          <div className="text-xs text-primary2">{winRate}%</div>
-        </div>
+      {/* 승률 pill */}
+      <div className="shrink-0">
+        <span
+          className={`inline-block rounded-md text-sm font-bold tabular-nums ${getWinRateColor(
+            winRate
+          )}`}
+          style={{ padding: "3px 10px", backgroundColor: pillBg }}
+        >
+          {winRate}%
+        </span>
       </div>
     </div>
   );

--- a/src/features/statistics/UserRankItem.tsx
+++ b/src/features/statistics/UserRankItem.tsx
@@ -55,7 +55,7 @@ const UserRankItem = ({
 
   return (
     <div
-      className={`bg-darkBg2 rounded-md border border-cardBorder pl-3 pr-6 sm:pl-3.5 sm:pr-10 py-[11px] flex items-center gap-2.5 sm:gap-3.5 ${
+      className={`bg-darkBg2 rounded-md border border-cardBorder pl-3 pr-4 sm:pl-3.5 sm:pr-10 py-[11px] flex items-center gap-1.5 sm:gap-3.5 ${
         className || ""
       }`}
     >
@@ -77,7 +77,7 @@ const UserRankItem = ({
         </div>
       )}
 
-      {/* 닉네임 + KDA */}
+      {/* 닉네임 */}
       <div className="flex-1 min-w-0 relative group">
         <button
           type="button"
@@ -86,7 +86,6 @@ const UserRankItem = ({
         >
           {riotName}
         </button>
-        <div className={`text-[11px] mt-0.5 tabular-nums ${getKdaColor(kda)}`}>KDA {kda}</div>
         <div className="absolute bottom-full left-0 mb-2 hidden group-hover:block px-3 py-1 rounded bg-black text-white z-10 whitespace-nowrap">
           <span>{riotName}</span>
           <span className="text-primary2"> #{riotNameTag}</span>
@@ -94,13 +93,20 @@ const UserRankItem = ({
         </div>
       </div>
 
+      {/* KDA */}
+      <div className="w-12 md:w-16 shrink-0 text-center">
+        <span className={`text-[13px] md:text-sm font-bold tabular-nums ${getKdaColor(kda)}`}>
+          {kda}
+        </span>
+      </div>
+
       {/* 전적 (n전 n승 n패) */}
-      <div className="w-28 md:w-40 shrink-0 text-center text-[13px] text-primary2 tabular-nums whitespace-nowrap">
+      <div className="w-24 md:w-40 shrink-0 text-center text-[13px] text-primary2 tabular-nums whitespace-nowrap">
         {formatNumber(totalGames)}전 {formatNumber(wins)}승 {formatNumber(losses)}패
       </div>
 
       {/* 승률 pill */}
-      <div className="w-14 md:w-[52px] shrink-0 flex justify-center">
+      <div className="w-12 md:w-[52px] shrink-0 flex justify-center">
         <span
           className={`inline-block rounded-md text-sm font-bold tabular-nums ${getWinRateColor(
             winRate

--- a/src/features/statistics/UserRankItem.tsx
+++ b/src/features/statistics/UserRankItem.tsx
@@ -64,9 +64,9 @@ const UserRankItem = ({
         {rank}
       </div>
 
-      {/* 라인 아이콘 32×32 */}
-      {position && (
-        <div className="shrink-0 w-8 h-8 flex items-center justify-center">
+      {/* 라인 아이콘 32×32 — 전체(라인 없음)에서도 자리를 유지해 행 높이를 일정하게 */}
+      <div className="shrink-0 w-8 h-8 flex items-center justify-center">
+        {position && (
           <Image
             src={laneImageMap[position] || LaneMidLogo}
             alt={position}
@@ -74,8 +74,8 @@ const UserRankItem = ({
             height={32}
             className="w-full h-full object-contain"
           />
-        </div>
-      )}
+        )}
+      </div>
 
       {/* 닉네임 */}
       <div className="flex-1 min-w-0 relative group">

--- a/src/features/statistics/UserRankItem.tsx
+++ b/src/features/statistics/UserRankItem.tsx
@@ -55,7 +55,7 @@ const UserRankItem = ({
 
   return (
     <div
-      className={`bg-darkBg2 rounded-md border border-cardBorder px-3 sm:px-3.5 py-[11px] flex items-center gap-2.5 sm:gap-3.5 ${
+      className={`bg-darkBg2 rounded-md border border-cardBorder pl-3 pr-6 sm:pl-3.5 sm:pr-10 py-[11px] flex items-center gap-2.5 sm:gap-3.5 ${
         className || ""
       }`}
     >

--- a/src/features/statistics/UserRankItem.tsx
+++ b/src/features/statistics/UserRankItem.tsx
@@ -46,32 +46,29 @@ const UserRankItem = ({
 }: Props) => {
   const router = useRouter();
 
-  const winRateValue = parseFloat(winRate.replace("%", ""));
-  const pillBg = winRateValue > 50 ? "rgba(255,195,100,0.14)" : "rgba(154,160,168,0.12)";
-
   const goToSummoner = () => {
     router.push(`/summoners/${encodeURIComponent(riotName)}/${encodeURIComponent(riotNameTag)}`);
   };
 
   return (
     <div
-      className={`bg-darkBg2 rounded-md border border-cardBorder pl-3 pr-4 sm:pl-3.5 sm:pr-10 py-[11px] flex items-center gap-1.5 sm:gap-3.5 ${
+      className={`bg-darkBg2 rounded-md border border-cardBorder px-3 sm:px-3.5 py-[11px] flex items-center gap-1.5 sm:gap-3.5 ${
         className || ""
       }`}
     >
       {/* 순위 (균일 — 1위 강조 없음) */}
-      <div className="w-[18px] shrink-0 text-center text-[15px] font-bold text-primary2 tabular-nums">
+      <div className="w-5 shrink-0 text-center text-[15px] font-bold text-primary2 tabular-nums">
         {rank}
       </div>
 
-      {/* 라인 아이콘 32×32 — 전체(라인 없음)에서도 자리를 유지해 행 높이를 일정하게 */}
-      <div className="shrink-0 w-8 h-8 flex items-center justify-center">
+      {/* 라인 아이콘 36×36 — 전체(라인 없음)에서도 자리를 유지해 행 높이를 일정하게 */}
+      <div className="shrink-0 w-8 sm:w-9 h-9 flex items-center justify-center">
         {position && (
           <Image
             src={laneImageMap[position] || LaneMidLogo}
             alt={position}
-            width={32}
-            height={32}
+            width={36}
+            height={36}
             className="w-full h-full object-contain"
           />
         )}
@@ -94,24 +91,21 @@ const UserRankItem = ({
       </div>
 
       {/* KDA */}
-      <div className="w-12 md:w-16 shrink-0 text-center">
-        <span className={`text-[13px] md:text-sm font-bold tabular-nums ${getKdaColor(kda)}`}>
-          {kda}
-        </span>
+      <div className="shrink-0 w-12 sm:w-16 text-center">
+        <div className={`text-[15px] font-bold tabular-nums ${getKdaColor(kda)}`}>{kda}</div>
       </div>
 
       {/* 전적 (n전 n승 n패) */}
-      <div className="w-24 md:w-40 shrink-0 text-center text-[13px] text-primary2 tabular-nums whitespace-nowrap">
+      <div className="shrink-0 w-[92px] sm:w-40 text-center text-[11px] sm:text-[13px] text-primary2 tabular-nums whitespace-nowrap overflow-hidden">
         {formatNumber(totalGames)}전 {formatNumber(wins)}승 {formatNumber(losses)}패
       </div>
 
       {/* 승률 pill */}
-      <div className="w-12 md:w-[52px] shrink-0 flex justify-center">
+      <div className="shrink-0 w-14 sm:w-16 flex justify-center">
         <span
-          className={`inline-block rounded-md text-sm font-bold tabular-nums ${getWinRateColor(
+          className={`inline-flex items-center rounded-md px-2 py-[3px] text-sm font-bold tabular-nums ${getWinRateColor(
             winRate
-          )}`}
-          style={{ padding: "3px 10px", backgroundColor: pillBg }}
+          )} ${parseFloat(winRate) > 50 ? "bg-yellow/10" : "bg-primary2/10"}`}
         >
           {winRate}%
         </span>

--- a/src/features/summonerRecord/EmptySearchResultCard.tsx
+++ b/src/features/summonerRecord/EmptySearchResultCard.tsx
@@ -9,11 +9,27 @@ interface Props {
 const EmptySearchResultCard = ({ riotName, riotTag }: Props) => {
   return (
     <main>
-      <Card className="w-full p-4 text-center text-white mt-14">
-        <p>
-          해당 클랜 내 &quot;{riotName}
-          {riotTag ? ` #${riotTag}` : ""}&quot;의 검색 결과가 없습니다.
-        </p>
+      <Card className="w-full mt-14">
+        <div className="flex flex-col items-center justify-center gap-2 px-4 py-7 text-center">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="#4A4F57"
+            strokeWidth={1.75}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="w-10 h-10"
+            aria-hidden="true"
+          >
+            <circle cx="11" cy="11" r="7" />
+            <path d="M21 21l-4.35-4.35" />
+          </svg>
+          <p className="text-sm text-primary1">검색 결과가 없습니다</p>
+          <p className="text-xs text-primary2">
+            해당 클랜 내 &quot;{riotName}
+            {riotTag ? ` #${riotTag}` : ""}&quot; 기록을 찾지 못했습니다.
+          </p>
+        </div>
       </Card>
     </main>
   );

--- a/src/features/summonerRecord/SummonerTabBar.tsx
+++ b/src/features/summonerRecord/SummonerTabBar.tsx
@@ -24,7 +24,7 @@ const SummonerTabBar = ({ activeTab, onTabChange }: Props) => (
         className={`px-7 py-3.5 text-base border-b-3 -mb-px transition-colors ${
           activeTab === key
             ? "text-primary1 font-bold border-blueText"
-            : "text-primary2 font-medium border-transparent hover:text-primary1"
+            : "text-primary2 font-normal border-transparent hover:text-primary1"
         }`}
       >
         {label}

--- a/src/features/summonerRecord/UserRecordPanel.tsx
+++ b/src/features/summonerRecord/UserRecordPanel.tsx
@@ -205,8 +205,8 @@ const UserRecordPanel = ({ riotName, riotTag, data, onRefreshRecords }: Props) =
           </div>
 
           {displayedRecords && displayedRecords.length > 0 && (
-            <CardWithTitle title="최근 전적" className="w-full">
-              <div className="flex flex-1 flex-col gap-4">
+            <CardWithTitle title="최근 전적" className="w-full min-w-0">
+              <div className="flex flex-1 flex-col gap-4 min-w-0">
                 {displayedRecords.map((datum: RecentGameRecord) => (
                   <MatchItem matchData={datum} key={datum.gameId} />
                 ))}

--- a/src/features/summonerRecord/UserRecordPanel.tsx
+++ b/src/features/summonerRecord/UserRecordPanel.tsx
@@ -251,7 +251,7 @@ const UserRecordPanel = ({ riotName, riotTag, data, onRefreshRecords }: Props) =
             {!(isLoadingMostPicks || isFetchingMostPicks) && sortedChampions.length > 0 && (
               <div className="flex flex-col gap-1">
                 {/* 열 제목 헤더 */}
-                <div className="flex items-center gap-1 sm:gap-3 px-2 sm:px-3 py-1 text-xs font-medium text-primary2">
+                <div className="flex items-center gap-1 sm:gap-3 px-2 sm:px-3 py-1 text-xs font-bold text-primary2">
                   <div className="w-5 sm:w-7 shrink-0" />
                   <div className="w-10 sm:w-12 shrink-0" />
                   <div className="flex-1 min-w-0 sm:w-28 sm:flex-none" />

--- a/src/features/summonerRecord/UserRecordPanel.tsx
+++ b/src/features/summonerRecord/UserRecordPanel.tsx
@@ -9,7 +9,7 @@ import {
   UserRecentRecordsResponse,
 } from "@/data/types/record";
 import MatchItem from "@/features/matchHistory/MatchItem";
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect, useRef } from "react";
 import { useQuery, useQueries } from "@tanstack/react-query";
 import { ApiResponse } from "@/services/apiService";
 import { getMostPicks, getRecentRecords } from "@/services/record";
@@ -35,7 +35,7 @@ type ChampionSortType = "gameCount" | "winRate" | "kda";
 const SHARE_LANES = ["TOP", "JUG", "MID", "ADC", "SUP"] as const;
 
 const UserRecordPanel = ({ riotName, riotTag, data, onRefreshRecords }: Props) => {
-  const RECORD_DISPLAY_COUNT = 5;
+  const RECORD_DISPLAY_COUNT = 10;
   const MOST_PICK_DISTPLAY_COUNT = 10;
   const guildId =
     typeof window !== "undefined" ? (localStorage.getItem("guildId") ?? undefined) : undefined;
@@ -49,11 +49,9 @@ const UserRecordPanel = ({ riotName, riotTag, data, onRefreshRecords }: Props) =
   });
   const [championPosition, setChampionPosition] = useState<Position>("ALL");
 
-  const {
-    data: recentRecordsData,
-    isFetching,
-    refetch: refetchRecentRecords,
-  } = useQuery<ApiResponse<UserRecentRecordsResponse>>({
+  const { data: recentRecordsData, refetch: refetchRecentRecords } = useQuery<
+    ApiResponse<UserRecentRecordsResponse>
+  >({
     queryKey: ["userRecentRecords", riotName, riotTag, guildId],
     queryFn: () => getRecentRecords(riotName, riotTag, guildId),
     staleTime: 3 * 60 * 1000,
@@ -101,6 +99,25 @@ const UserRecordPanel = ({ riotName, riotTag, data, onRefreshRecords }: Props) =
   const allRecords = recentRecordsData?.data?.data || [];
   const displayedRecords = allRecords.slice(0, displayCount);
   const hasMoreData = allRecords.length > displayCount;
+
+  // 무한 스크롤: 하단 센티넬이 뷰포트에 들어오면 표시 개수를 늘린다.
+  // displayCount 변경 시 옵저버를 재생성해, 센티넬이 여전히 보이면 연속으로 더 채운다.
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!hasMoreData) return undefined;
+    const target = loadMoreRef.current;
+    if (!target) return undefined;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          setDisplayCount((prev) => prev + RECORD_DISPLAY_COUNT);
+        }
+      },
+      { rootMargin: "300px" }
+    );
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [hasMoreData, displayCount]);
 
   const mostLane = data.lines.reduce((prev, curr) =>
     curr.totalCount > prev.totalCount ? curr : prev
@@ -212,14 +229,23 @@ const UserRecordPanel = ({ riotName, riotTag, data, onRefreshRecords }: Props) =
                 ))}
 
                 {hasMoreData && (
-                  <button
-                    type="button"
-                    onClick={() => setDisplayCount((prev) => prev + RECORD_DISPLAY_COUNT)}
-                    disabled={isFetching}
-                    className="w-full py-3 rounded bg-darkBg2 border border-border2 text-primary1 hover:bg-grayHover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  <div
+                    ref={loadMoreRef}
+                    className="flex items-center justify-center gap-2 py-4 text-sm text-primary2"
                   >
-                    {isFetching ? "불러오는 중..." : "더보기"}
-                  </button>
+                    <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+                    </svg>
+                    불러오는 중...
+                  </div>
                 )}
               </div>
             </CardWithTitle>

--- a/src/pages/champion/index.tsx
+++ b/src/pages/champion/index.tsx
@@ -207,10 +207,10 @@ const Champion: NextPage = () => {
                 key={mode}
                 type="button"
                 onClick={() => setDateMode(mode)}
-                className={`px-3 py-1.5 rounded-md text-sm font-medium transition-all duration-200 ${
+                className={`px-3 py-1.5 rounded-md text-sm transition-all duration-200 ${
                   dateMode === mode
-                    ? "bg-primary1 text-darkBg2 shadow"
-                    : "text-primary2 hover:text-primary1"
+                    ? "bg-blue text-blueText font-bold"
+                    : "text-primary2 font-normal hover:text-primary1"
                 }`}
               >
                 {labels[mode]}
@@ -290,7 +290,7 @@ const Champion: NextPage = () => {
             <button
               type="button"
               onClick={handleApplyRange}
-              className="px-3 py-1.5 rounded-lg text-sm font-medium bg-blueButton hover:bg-blueText2 text-white transition-colors duration-150"
+              className="px-3 py-1.5 rounded-lg text-sm font-bold bg-bluePrimary hover:opacity-90 text-white transition-opacity duration-150"
             >
               적용
             </button>

--- a/src/pages/champion/index.tsx
+++ b/src/pages/champion/index.tsx
@@ -4,7 +4,6 @@ import React, { useState, useEffect, useRef, useMemo, useCallback } from "react"
 import useUserSearchController from "@/hooks/searchUserList/useUserSearchController";
 import useGuildManagement from "@/hooks/auth/useGuildManagement";
 import TitleBox from "@/components/ui/TitleBox";
-import PositionFilter from "@/features/statistics/PositionFilter";
 import ChampionRankHeader from "@/features/statistics/ChampionRankHeader";
 import ChampionRankItem from "@/features/statistics/ChampionRankItem";
 import { useQuery } from "@tanstack/react-query";
@@ -14,7 +13,7 @@ import { ChampionStatisticsResponse } from "@/data/types/statistics";
 import TextCard from "@/components/ui/TextCard";
 
 type DateMode = "recent" | "season" | "range";
-type SortBy = "totalGames" | "winRate";
+type SortBy = "totalGames" | "winRate" | "kda";
 type SortOrder = "asc" | "desc";
 
 const now = new Date();
@@ -45,7 +44,8 @@ const SELECT_CLASS =
 
 const Champion: NextPage = () => {
   const [searchTerm, setSearchTerm] = useState("");
-  const [selectedPosition, setSelectedPosition] = useState<Position>("ALL");
+  // 라인 필터 제거 — 항상 전체(ALL) 기준으로 조회한다.
+  const selectedPosition: Position = "ALL";
   const [displayCount, setDisplayCount] = useState(10);
   const [sortBy, setSortBy] = useState<SortBy>("winRate");
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
@@ -134,11 +134,12 @@ const Champion: NextPage = () => {
 
   const sortedChampions = useMemo(() => {
     const champions = [...(championStatisticsData?.data?.data || [])];
-    champions.sort((a, b) => {
-      const aValue = sortBy === "totalGames" ? a.totalCount : parseFloat(a.winRate) || 0;
-      const bValue = sortBy === "totalGames" ? b.totalCount : parseFloat(b.winRate) || 0;
-      return sortOrder === "asc" ? aValue - bValue : bValue - aValue;
-    });
+    const metric = (c: (typeof champions)[number]) => {
+      if (sortBy === "totalGames") return c.totalCount;
+      if (sortBy === "kda") return parseFloat(c.kda) || 0;
+      return parseFloat(c.winRate) || 0;
+    };
+    champions.sort((a, b) => (sortOrder === "asc" ? metric(a) - metric(b) : metric(b) - metric(a)));
     return champions;
   }, [championStatisticsData?.data?.data, sortBy, sortOrder]);
 
@@ -298,13 +299,7 @@ const Champion: NextPage = () => {
         )}
       </div>
 
-      <PositionFilter
-        selectedPosition={selectedPosition}
-        onSelectPosition={setSelectedPosition}
-        className="mt-4"
-      />
-
-      <div className="mt-1">
+      <div className="mt-4">
         <ChampionRankHeader sortBy={sortBy} sortOrder={sortOrder} onSort={handleSort} />
         <div key={selectedPosition} className="space-y-3 mt-2">
           {(() => {
@@ -352,6 +347,7 @@ const Champion: NextPage = () => {
                             championNameEng={champion.champNameEng}
                             position={champion.position}
                             winRate={champion.winRate}
+                            kda={champion.kda}
                             gameCount={champion.totalCount}
                             tier={tier}
                             isPopular={isPopular}

--- a/src/pages/replay/index.tsx
+++ b/src/pages/replay/index.tsx
@@ -32,6 +32,7 @@ const Replay: NextPage = () => {
   const [isUploading, setIsUploading] = useState(false);
   const [uploadResult, setUploadResult] = useState<ReplayUploadData | null>(null);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [copiedCode, setCopiedCode] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const { guildId, guilds, isLoggedIn, username, handleGuildChange } = useGuildManagement();
@@ -57,6 +58,8 @@ const Replay: NextPage = () => {
   });
 
   const replayList = replayListData?.data?.data?.slice(0, 10) ?? [];
+
+  const totalSizeMB = (files.reduce((sum, f) => sum + f.size, 0) / 1024 / 1024).toFixed(1);
 
   const addFiles = useCallback((incoming: FileList | null) => {
     if (!incoming) return;
@@ -88,6 +91,16 @@ const Replay: NextPage = () => {
     e.preventDefault();
     setIsDragging(false);
     addFiles(e.dataTransfer.files);
+  };
+
+  const handleCopy = async (code: string) => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopiedCode(code);
+      setTimeout(() => setCopiedCode((prev) => (prev === code ? null : prev)), 1500);
+    } catch {
+      setCopiedCode(null);
+    }
   };
 
   const handleUpload = async () => {
@@ -136,288 +149,393 @@ const Replay: NextPage = () => {
         description="내전 리플레이 파일(.rofl)을 업로드하면 자동으로 전적에 반영됩니다."
       />
 
-      {/* 파일 업로드 섹션 */}
-      <section className="mt-4 bg-darkBg2 border border-border2 rounded p-4 space-y-4">
-        <h2 className="text-sm font-bold text-primary1">파일 업로드</h2>
-
-        {(() => {
-          if (!isLoggedIn) return <TextCard text="로그인 후 이용해주세요" />;
-          if (guilds.length === 0) return <TextCard text="소속된 클랜이 없습니다" />;
-          return (
-            <>
-              {/* 드래그 앤 드롭 존 */}
-              <div
-                role="button"
-                tabIndex={0}
-                onDragOver={handleDragOver}
-                onDragLeave={handleDragLeave}
-                onDrop={handleDrop}
-                onClick={() => fileInputRef.current?.click()}
-                onKeyDown={(e) => e.key === "Enter" && fileInputRef.current?.click()}
-                className={`flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed py-10 cursor-pointer transition-colors duration-150 select-none ${
-                  isDragging
-                    ? "border-blueText bg-blueHover"
-                    : "border-border1 hover:border-blueText2 hover:bg-rankBg3"
-                }`}
+      {/* 콘솔: 업로드(좌) + 최근 업로드(우) */}
+      <div className="mt-4 mb-10 grid grid-cols-1 lg:grid-cols-[1.6fr_1fr] gap-4 items-start">
+        {/* 파일 업로드 패널 */}
+        <section className="bg-darkBg2 border border-border2 rounded-lg overflow-hidden">
+          <div className="flex items-center gap-2 px-4 py-3 border-b border-border2">
+            <span className="w-[22px] h-[22px] rounded-md grid place-items-center bg-blueText/10 text-blueText">
+              <svg
+                className="w-3.5 h-3.5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
               >
-                <svg
-                  className={`w-10 h-10 ${isDragging ? "text-blueText" : "text-primary2"}`}
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={1.5}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
-                  />
-                </svg>
-                <p className={`text-sm ${isDragging ? "text-blueText" : "text-primary2"}`}>
-                  파일을 끌어다 놓거나{" "}
-                  <span className="text-blueText2 underline underline-offset-2">클릭하여 선택</span>
-                  하세요
-                </p>
-                <p className="text-xs text-primary2 opacity-60">.rofl 파일만 업로드 가능합니다</p>
-              </div>
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
+                />
+              </svg>
+            </span>
+            <h2 className="text-sm font-bold text-primary1">파일 업로드</h2>
+          </div>
 
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept=".rofl"
-                multiple
-                className="hidden"
-                onChange={(e) => addFiles(e.target.files)}
-              />
-
-              {/* 선택된 파일 목록 */}
-              {files.length > 0 && (
-                <ul className="space-y-1.5">
-                  {files.map((file, index) => (
-                    <li
-                      key={file.name}
-                      className="flex items-center justify-between bg-rankBg2 rounded px-3 py-2 text-sm"
+          <div className="p-4 flex flex-col gap-3.5">
+            {(() => {
+              if (!isLoggedIn) return <TextCard text="로그인 후 이용해주세요" />;
+              if (guilds.length === 0) return <TextCard text="소속된 클랜이 없습니다" />;
+              return (
+                <>
+                  {/* 드래그 앤 드롭 존 */}
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    onDragOver={handleDragOver}
+                    onDragLeave={handleDragLeave}
+                    onDrop={handleDrop}
+                    onClick={() => fileInputRef.current?.click()}
+                    onKeyDown={(e) => e.key === "Enter" && fileInputRef.current?.click()}
+                    className={`flex flex-col items-center justify-center gap-2.5 rounded-xl border-2 border-dashed py-9 px-5 cursor-pointer transition-colors duration-150 select-none text-center ${
+                      isDragging
+                        ? "border-blueText bg-blueHover"
+                        : "border-border1 hover:border-blueText2 hover:bg-rankBg3"
+                    }`}
+                  >
+                    <span
+                      className={`w-[52px] h-[52px] rounded-2xl grid place-items-center transition-colors ${
+                        isDragging ? "bg-blueText/20 text-blueText" : "bg-blueText/10 text-primary2"
+                      }`}
                     >
-                      <div className="flex items-center gap-2 min-w-0">
-                        <svg
-                          className="w-4 h-4 text-blueText2 flex-shrink-0"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25z"
-                          />
-                        </svg>
-                        <span className="text-primary1 truncate">{file.name}</span>
-                        <span className="text-primary2 text-xs flex-shrink-0">
-                          ({(file.size / 1024 / 1024).toFixed(1)} MB)
-                        </span>
-                      </div>
-                      <button
-                        type="button"
-                        aria-label={`${file.name} 제거`}
-                        onClick={() => removeFile(index)}
-                        className="text-primary2 hover:text-redText transition-colors flex-shrink-0 ml-2"
+                      <svg
+                        className="w-[26px] h-[26px]"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={1.5}
                       >
-                        <svg
-                          className="w-4 h-4"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M6 18L18 6M6 6l12 12"
-                          />
-                        </svg>
-                      </button>
-                    </li>
-                  ))}
-                </ul>
-              )}
-
-              {/* 업로드 버튼 */}
-              <div className="flex justify-end">
-                <button
-                  type="button"
-                  onClick={handleUpload}
-                  disabled={files.length === 0 || isUploading}
-                  className={`px-5 py-2 rounded-lg text-sm font-bold transition-all duration-150 ${
-                    files.length === 0 || isUploading
-                      ? "bg-rankBg1 text-primary2 cursor-not-allowed opacity-50"
-                      : "bg-bluePrimary hover:opacity-90 text-white"
-                  }`}
-                >
-                  {isUploading ? (
-                    <span className="flex items-center gap-2">
-                      <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                        <circle
-                          className="opacity-25"
-                          cx="12"
-                          cy="12"
-                          r="10"
-                          stroke="currentColor"
-                          strokeWidth="4"
-                        />
                         <path
-                          className="opacity-75"
-                          fill="currentColor"
-                          d="M4 12a8 8 0 018-8v8H4z"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
                         />
                       </svg>
-                      업로드 중...
                     </span>
-                  ) : (
-                    `업로드 (${files.length}개)`
-                  )}
-                </button>
-              </div>
+                    <p className={`text-sm ${isDragging ? "text-blueText" : "text-primary1"}`}>
+                      파일을 끌어다 놓거나{" "}
+                      <span className="text-blueText underline underline-offset-2">
+                        클릭하여 선택
+                      </span>
+                      하세요
+                    </p>
+                    <span className="inline-flex items-center gap-1.5 text-[11px] text-primary3 border border-border1 rounded-full px-2.5 py-[3px]">
+                      <b className="text-blueText2 font-bold">.rofl</b> 파일만 업로드 가능
+                    </span>
+                  </div>
 
-              {/* 업로드 오류 */}
-              {uploadError && (
-                <div className="flex items-center gap-2 bg-redDarken border border-redLighten rounded px-4 py-3 text-sm text-redText">
-                  <svg
-                    className="w-4 h-4 flex-shrink-0"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={2}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
-                    />
-                  </svg>
-                  {uploadError}
-                </div>
-              )}
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".rofl"
+                    multiple
+                    className="hidden"
+                    onChange={(e) => addFiles(e.target.files)}
+                  />
 
-              {/* 업로드 결과 */}
-              {uploadResult && (
-                <div className="space-y-3">
-                  {uploadResult.succeeded.length > 0 && (
-                    <div className="space-y-1.5">
-                      <p className="text-xs font-bold text-neonGreen">
-                        성공 ({uploadResult.succeeded.length}건)
-                      </p>
-                      {uploadResult.succeeded.map((item: ReplayUploadSuccess) => (
-                        <div
-                          key={item.replayCode}
-                          className="flex items-center justify-between bg-rankBg2 border border-border1 rounded px-3 py-2 text-sm"
+                  {/* 선택된 파일 목록 */}
+                  {files.length > 0 && (
+                    <>
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-bold text-primary2">선택된 파일</span>
+                        <button
+                          type="button"
+                          onClick={() => setFiles([])}
+                          className="text-xs text-primary3 hover:text-redText transition-colors"
                         >
-                          <div className="flex items-center gap-2">
-                            <svg
-                              className="w-4 h-4 text-neonGreen flex-shrink-0"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                              strokeWidth={2.5}
+                          모두 지우기
+                        </button>
+                      </div>
+
+                      <ul className="flex flex-col gap-2">
+                        {files.map((file, index) => (
+                          <li
+                            key={file.name}
+                            className="flex items-center gap-2.5 bg-rankBg2 border border-cardBorder rounded-lg px-3 py-2.5"
+                          >
+                            <span className="shrink-0 text-[9px] font-extrabold tracking-wide leading-none text-yellow bg-yellow/10 border border-yellow/25 rounded-[5px] px-1.5 py-1">
+                              ROFL
+                            </span>
+                            <span className="flex-1 min-w-0 truncate text-[13px] text-primary1">
+                              {file.name}
+                            </span>
+                            <span className="shrink-0 text-[11px] text-primary2 tabular-nums">
+                              {(file.size / 1024 / 1024).toFixed(1)} MB
+                            </span>
+                            <button
+                              type="button"
+                              aria-label={`${file.name} 제거`}
+                              onClick={() => removeFile(index)}
+                              className="shrink-0 w-6 h-6 rounded-md grid place-items-center text-primary3 hover:text-redText hover:bg-redText/10 transition-colors"
                             >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M4.5 12.75l6 6 9-13.5"
-                              />
-                            </svg>
-                            <span className="text-primary1">{item.fileName}</span>
-                          </div>
-                          <span className="text-xs text-blueText2 font-mono">
-                            {item.replayCode}
-                          </span>
-                        </div>
-                      ))}
+                              <svg
+                                className="w-[15px] h-[15px]"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={2}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M6 18L18 6M6 6l12 12"
+                                />
+                              </svg>
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+
+                      {/* 요약 + 업로드 버튼 */}
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="text-xs text-primary3 tabular-nums">
+                          총 <b className="text-primary2 font-bold">{files.length}개</b> ·{" "}
+                          {totalSizeMB} MB
+                        </span>
+                        <button
+                          type="button"
+                          onClick={handleUpload}
+                          disabled={files.length === 0 || isUploading}
+                          className={`inline-flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-bold transition-all duration-150 ${
+                            files.length === 0 || isUploading
+                              ? "bg-rankBg1 text-primary2 cursor-not-allowed opacity-50"
+                              : "bg-bluePrimary hover:opacity-90 text-white"
+                          }`}
+                        >
+                          {isUploading ? (
+                            <>
+                              <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                                <circle
+                                  className="opacity-25"
+                                  cx="12"
+                                  cy="12"
+                                  r="10"
+                                  stroke="currentColor"
+                                  strokeWidth="4"
+                                />
+                                <path
+                                  className="opacity-75"
+                                  fill="currentColor"
+                                  d="M4 12a8 8 0 018-8v8H4z"
+                                />
+                              </svg>
+                              업로드 중...
+                            </>
+                          ) : (
+                            <>
+                              <svg
+                                className="w-4 h-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={2}
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
+                                />
+                              </svg>
+                              업로드 ({files.length})
+                            </>
+                          )}
+                        </button>
+                      </div>
+                    </>
+                  )}
+
+                  {/* 업로드 오류 */}
+                  {uploadError && (
+                    <div className="flex items-center gap-2 bg-redDarken border border-redLighten rounded-md px-4 py-3 text-sm text-redText">
+                      <svg
+                        className="w-4 h-4 flex-shrink-0"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+                        />
+                      </svg>
+                      {uploadError}
                     </div>
                   )}
-                  {uploadResult.failed.length > 0 && (
-                    <div className="space-y-1.5">
-                      <p className="text-xs font-bold text-redText">
-                        실패 ({uploadResult.failed.length}건)
-                      </p>
-                      {uploadResult.failed.map((item: ReplayUploadFailed) => (
-                        <div
-                          key={item.fileName}
-                          className="flex items-center justify-between bg-redDarken border border-redLighten rounded px-3 py-2 text-sm"
-                        >
-                          <div className="flex items-center gap-2">
-                            <svg
-                              className="w-4 h-4 text-redText flex-shrink-0"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                              strokeWidth={2.5}
+
+                  {/* 업로드 결과 */}
+                  {uploadResult && (
+                    <div className="flex flex-col gap-3">
+                      {uploadResult.succeeded.length > 0 && (
+                        <div className="flex flex-col gap-1.5">
+                          <p className="text-xs font-bold text-neonGreen">
+                            성공 ({uploadResult.succeeded.length}건)
+                          </p>
+                          {uploadResult.succeeded.map((item: ReplayUploadSuccess) => (
+                            <div
+                              key={item.replayCode}
+                              className="flex items-center justify-between gap-2.5 bg-rankBg2 border border-border1 rounded-md px-3 py-2 text-sm"
                             >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M6 18L18 6M6 6l12 12"
-                              />
-                            </svg>
-                            <span className="text-primary1">{item.fileName}</span>
-                          </div>
-                          <span className="text-xs text-redText">
-                            {item.reason.includes("duplicate")
-                              ? "이미 등록된 리플레이 데이터입니다"
-                              : FAIL_REASON_LABEL[item.reason]}
-                          </span>
+                              <div className="flex items-center gap-2 min-w-0">
+                                <svg
+                                  className="w-4 h-4 text-neonGreen flex-shrink-0"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  strokeWidth={2.5}
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M4.5 12.75l6 6 9-13.5"
+                                  />
+                                </svg>
+                                <span className="text-primary1 truncate">{item.fileName}</span>
+                              </div>
+                              <span className="text-xs text-blueText2 font-mono flex-shrink-0">
+                                {item.replayCode}
+                              </span>
+                            </div>
+                          ))}
                         </div>
-                      ))}
+                      )}
+                      {uploadResult.failed.length > 0 && (
+                        <div className="flex flex-col gap-1.5">
+                          <p className="text-xs font-bold text-redText">
+                            실패 ({uploadResult.failed.length}건)
+                          </p>
+                          {uploadResult.failed.map((item: ReplayUploadFailed) => (
+                            <div
+                              key={item.fileName}
+                              className="flex items-center justify-between gap-2.5 bg-redDarken border border-redLighten rounded-md px-3 py-2 text-sm"
+                            >
+                              <div className="flex items-center gap-2 min-w-0">
+                                <svg
+                                  className="w-4 h-4 text-redText flex-shrink-0"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                  strokeWidth={2.5}
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M6 18L18 6M6 6l12 12"
+                                  />
+                                </svg>
+                                <span className="text-primary1 truncate">{item.fileName}</span>
+                              </div>
+                              <span className="text-xs text-redText flex-shrink-0">
+                                {item.reason.includes("duplicate")
+                                  ? "이미 등록된 리플레이 데이터입니다"
+                                  : FAIL_REASON_LABEL[item.reason]}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      )}
                     </div>
                   )}
-                </div>
-              )}
-            </>
-          );
-        })()}
-      </section>
+                </>
+              );
+            })()}
+          </div>
+        </section>
 
-      {/* 최근 업로드 섹션 */}
-      <section className="mt-4 mb-10 bg-darkBg2 border border-border2 rounded p-4">
-        <div className="flex items-center gap-2 mb-3">
-          <h2 className="text-sm font-bold text-primary1">최근 업로드</h2>
-          <span className="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full bg-rankBg1 border border-border1 text-xs text-primary2">
-            {replayList.length}
-          </span>
-        </div>
-
-        {/* 헤더 */}
-        <div className="grid grid-cols-[1.5rem_70px_60px_1fr] sm:grid-cols-[2rem_120px_90px_1fr] gap-2 px-3 py-2 text-xs text-primary2 border-b border-border2">
-          <span>#</span>
-          <span>게시자</span>
-          <span>시간</span>
-          <span>리플레이 코드</span>
-        </div>
-
-        {isLoadingList && (
-          <div className="text-center py-8 text-sm text-primary2">데이터를 불러오는 중...</div>
-        )}
-
-        {!isLoadingList && replayList.length === 0 && (
-          <div className="text-center py-8 text-sm text-primary2">업로드된 리플레이가 없습니다</div>
-        )}
-
-        {!isLoadingList && replayList.length > 0 && (
-          <ul>
-            {replayList.map((log, index) => (
-              <li
-                key={log.replayCode}
-                className="grid grid-cols-[1.5rem_70px_60px_1fr] sm:grid-cols-[2rem_120px_90px_1fr] gap-2 items-center px-3 py-2.5 text-sm border-b border-border2 last:border-0 hover:bg-rankBg3 transition-colors"
+        {/* 최근 업로드 패널 */}
+        <section className="bg-darkBg2 border border-border2 rounded-lg overflow-hidden">
+          <div className="flex items-center gap-2 px-4 py-3 border-b border-border2">
+            <span className="w-[22px] h-[22px] rounded-md grid place-items-center bg-blueText/10 text-blueText">
+              <svg
+                className="w-3.5 h-3.5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
               >
-                <span className="text-primary2 text-xs">{index + 1}</span>
-                <span className="text-primary1 truncate">{log.createUser}</span>
-                <span className="text-primary2 text-xs">{formatTimeAgo(log.createDate)}</span>
-                <span className="text-blueText2 font-mono text-xs truncate">{log.replayCode}</span>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 6v6l4 2m6-2a10 10 0 11-20 0 10 10 0 0120 0z"
+                />
+              </svg>
+            </span>
+            <h2 className="text-sm font-bold text-primary1">최근 업로드</h2>
+            <span className="ml-auto inline-flex items-center justify-center min-w-[22px] h-5 px-1.5 rounded-full bg-rankBg1 border border-border1 text-[11px] text-primary2 tabular-nums">
+              {replayList.length}
+            </span>
+          </div>
+
+          <div className="px-3 py-1.5">
+            {isLoadingList && (
+              <div className="text-center py-10 text-sm text-primary2">데이터를 불러오는 중...</div>
+            )}
+
+            {!isLoadingList && replayList.length === 0 && (
+              <div className="text-center py-10 text-sm text-primary2">
+                업로드된 리플레이가 없습니다
+              </div>
+            )}
+
+            {!isLoadingList && replayList.length > 0 && (
+              <ul className="flex flex-col">
+                {replayList.map((log) => (
+                  <li
+                    key={log.replayCode}
+                    className="flex items-center gap-3 px-1.5 py-2.5 border-b border-rankBg3 last:border-0"
+                  >
+                    <div className="min-w-0 flex-1 flex flex-col gap-0.5">
+                      <span className="text-[13px] text-primary1 truncate">{log.createUser}</span>
+                      <span className="text-[11px] text-blueText2 font-mono truncate">
+                        {log.replayCode}
+                      </span>
+                    </div>
+                    <div className="shrink-0 flex items-center gap-2">
+                      <span className="text-[11px] text-primary3 tabular-nums">
+                        {formatTimeAgo(log.createDate)}
+                      </span>
+                      <button
+                        type="button"
+                        aria-label="리플레이 코드 복사"
+                        onClick={() => handleCopy(log.replayCode)}
+                        className="w-[26px] h-[26px] rounded-md grid place-items-center border border-border1 text-primary3 hover:text-blueText hover:border-blueText2 transition-colors"
+                      >
+                        {copiedCode === log.replayCode ? (
+                          <svg
+                            className="w-3.5 h-3.5 text-neonGreen"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={2.5}
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M4.5 12.75l6 6 9-13.5"
+                            />
+                          </svg>
+                        ) : (
+                          <svg
+                            className="w-[13px] h-[13px]"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={2}
+                          >
+                            <rect x="9" y="9" width="11" height="11" rx="2" />
+                            <path d="M5 15V5a2 2 0 012-2h10" />
+                          </svg>
+                        )}
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </section>
+      </div>
     </div>
   );
 };

--- a/src/pages/replay/index.tsx
+++ b/src/pages/replay/index.tsx
@@ -138,7 +138,7 @@ const Replay: NextPage = () => {
 
       {/* 파일 업로드 섹션 */}
       <section className="mt-4 bg-darkBg2 border border-border2 rounded p-4 space-y-4">
-        <h2 className="text-sm font-medium text-primary1">파일 업로드</h2>
+        <h2 className="text-sm font-bold text-primary1">파일 업로드</h2>
 
         {(() => {
           if (!isLoggedIn) return <TextCard text="로그인 후 이용해주세요" />;
@@ -248,10 +248,10 @@ const Replay: NextPage = () => {
                   type="button"
                   onClick={handleUpload}
                   disabled={files.length === 0 || isUploading}
-                  className={`px-5 py-2 rounded-lg text-sm font-medium transition-all duration-150 ${
+                  className={`px-5 py-2 rounded-lg text-sm font-bold transition-all duration-150 ${
                     files.length === 0 || isUploading
                       ? "bg-rankBg1 text-primary2 cursor-not-allowed opacity-50"
-                      : "bg-blueButton hover:bg-blueText2 text-white"
+                      : "bg-bluePrimary hover:opacity-90 text-white"
                   }`}
                 >
                   {isUploading ? (
@@ -304,7 +304,7 @@ const Replay: NextPage = () => {
                 <div className="space-y-3">
                   {uploadResult.succeeded.length > 0 && (
                     <div className="space-y-1.5">
-                      <p className="text-xs font-medium text-neonGreen">
+                      <p className="text-xs font-bold text-neonGreen">
                         성공 ({uploadResult.succeeded.length}건)
                       </p>
                       {uploadResult.succeeded.map((item: ReplayUploadSuccess) => (
@@ -337,7 +337,7 @@ const Replay: NextPage = () => {
                   )}
                   {uploadResult.failed.length > 0 && (
                     <div className="space-y-1.5">
-                      <p className="text-xs font-medium text-redText">
+                      <p className="text-xs font-bold text-redText">
                         실패 ({uploadResult.failed.length}건)
                       </p>
                       {uploadResult.failed.map((item: ReplayUploadFailed) => (
@@ -380,7 +380,7 @@ const Replay: NextPage = () => {
       {/* 최근 업로드 섹션 */}
       <section className="mt-4 mb-10 bg-darkBg2 border border-border2 rounded p-4">
         <div className="flex items-center gap-2 mb-3">
-          <h2 className="text-sm font-medium text-primary1">최근 업로드</h2>
+          <h2 className="text-sm font-bold text-primary1">최근 업로드</h2>
           <span className="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full bg-rankBg1 border border-border1 text-xs text-primary2">
             {replayList.length}
           </span>

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -14,7 +14,7 @@ import { UserStatisticsResponse } from "@/data/types/statistics";
 import TextCard from "@/components/ui/TextCard";
 
 type DateMode = "recent" | "season" | "range";
-type SortBy = "totalGames" | "winRate";
+type SortBy = "totalGames" | "winRate" | "kda";
 type SortOrder = "asc" | "desc";
 
 const now = new Date();
@@ -134,6 +134,9 @@ const User: NextPage = () => {
       if (sortBy === "totalGames") {
         aValue = a.totalCount || 0;
         bValue = b.totalCount || 0;
+      } else if (sortBy === "kda") {
+        aValue = parseFloat(a.kda) || 0;
+        bValue = parseFloat(b.kda) || 0;
       } else {
         aValue = parseFloat(a.winRate) || 0;
         bValue = parseFloat(b.winRate) || 0;

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -214,10 +214,10 @@ const User: NextPage = () => {
                 key={mode}
                 type="button"
                 onClick={() => setDateMode(mode)}
-                className={`px-3 py-1.5 rounded-md text-sm font-medium transition-all duration-200 ${
+                className={`px-3 py-1.5 rounded-md text-sm transition-all duration-200 ${
                   dateMode === mode
-                    ? "bg-primary1 text-darkBg2 shadow"
-                    : "text-primary2 hover:text-primary1"
+                    ? "bg-blue text-blueText font-bold"
+                    : "text-primary2 font-normal hover:text-primary1"
                 }`}
               >
                 {labels[mode]}
@@ -297,7 +297,7 @@ const User: NextPage = () => {
             <button
               type="button"
               onClick={handleApplyRange}
-              className="px-3 py-1.5 rounded-lg text-sm font-medium bg-blueButton hover:bg-blueText2 text-white transition-colors duration-150"
+              className="px-3 py-1.5 rounded-lg text-sm font-bold bg-bluePrimary hover:opacity-90 text-white transition-opacity duration-150"
             >
               적용
             </button>

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -342,7 +342,7 @@ const User: NextPage = () => {
                         <UserRankItem
                           key={user.playerCode}
                           rank={index + 1}
-                          position={selectedPosition === "ALL" ? undefined : user.position}
+                          position={user.position}
                           riotName={user.riotName}
                           riotNameTag={user.riotNameTag}
                           totalGames={user.totalCount}

--- a/src/styles/colors.js
+++ b/src/styles/colors.js
@@ -11,10 +11,12 @@ const colors = {
   rankBg3: "#141619",
   border1: "#363B41",
   border2: "#343842",
+  cardBorder: "#22252B", // 카드/행 테두리(스코어보드·랭크 행)
   primary1: "#D1DBE8",
-  primary2: "#797F87",
+  primary2: "#9AA0A8", // 보조 텍스트(대비 상향, 앱 전역)
+  primary3: "#6B7078", // 최하위 미세 라벨(열 제목, 챔피언 서브명, 캡션)
   red: "#351314",
-  redPopular: "#FF4E4E",
+  redPopular: "#F2789F", // "인기" 배지 로즈
   redLighten: "#664446",
   redDarken: "#1A1010",
   redHover: "#2e0606",
@@ -33,7 +35,23 @@ const colors = {
   yellow: "#FFC364",
   neonGreen: "#71FF97",
   tierBlue: "#2457FF",
-  tierBrown: "#AC6C70",
+  tierBrown: "#C94F77", // Tier-5 배지 로즈
+  // 팀 강조색 (스코어보드/바)
+  teamWin: "#58A6FF",
+  teamLoss: "#F2789F",
+  winRowBg: "#0E1A2B", // 승리 팀 헤더 틴트 배경
+  loseRowBg: "#241019", // 패배 팀 헤더/행 틴트 배경
+  primaryLaneBg: "#111826", // 주 포지션 하이라이트 배경
+  primaryLaneBorder: "#23324A",
+  // 주요 액션 버튼(단일 primary)
+  bluePrimary: "#3B82F6",
+  // 데미지 게이지
+  damageAmberFrom: "#E8913C",
+  damageAmberTo: "#F5C877",
+  damageSlate: "#6B74A0",
+  // 기타
+  slotEmpty: "#1C1F24", // 빈 아이템 슬롯 / 바 트랙
+  levelBadgeBg: "#0A0B0D",
 };
 
 module.exports = colors;

--- a/src/utils/statColors.ts
+++ b/src/utils/statColors.ts
@@ -5,10 +5,10 @@
  * @returns Tailwind CSS 색상 클래스
  *
  * 색상 기준:
- * - 3 이하: text-primary2 (회색)
- * - 3 초과 5 이하: text-neonGreen (초록)
- * - 5 초과 7 이하: text-blueText (파랑)
- * - 7 초과: text-yellow (주황)
+ * - 3 이하: text-primary2 (#9AA0A8, 회색)
+ * - 3 초과 5 이하: text-neonGreen (#71FF97, 초록)
+ * - 5 초과 7 이하: text-blueText (#6BB8FF, 파랑)
+ * - 7 초과: text-yellow (#FFC364, 주황)
  */
 export const getKdaColor = (kda: string | number): string => {
   const kdaValue = typeof kda === "string" ? parseFloat(kda) : kda;
@@ -36,8 +36,8 @@ export const getKdaColor = (kda: string | number): string => {
  * @returns Tailwind CSS 색상 클래스
  *
  * 색상 기준:
- * - 50% 이하: text-primary2 (회색)
- * - 50% 초과: text-yellow (주황)
+ * - 50% 이하: text-primary2 (#9AA0A8, 회색)
+ * - 50% 초과: text-yellow (#FFC364, 주황)
  */
 export const getWinRateColor = (winRate: string | number): string => {
   let winRateValue: number;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,6 +22,15 @@ module.exports = {
       borderWidth: {
         3: "3px",
       },
+      keyframes: {
+        fadeUp: {
+          "0%": { opacity: "0", transform: "translateY(10px)" },
+          "100%": { opacity: "1", transform: "translateY(0)" },
+        },
+      },
+      animation: {
+        fadeUp: "fadeUp 0.42s cubic-bezier(0.22, 1, 0.36, 1) both",
+      },
     },
   },
   plugins: [require("tailwind-scrollbar")],


### PR DESCRIPTION
## 주요 변경사항

### 📊 통계 분석 (챔피언 / 유저)

* 챔피언 통계와 유저 통계의 컬럼 구성 및 간격을 동일하게 맞춤
* 판수와 승률을 각각 별도 컬럼으로 분리
* KDA 컬럼 추가 및 정렬 기능 지원
* 챔피언 티어 배지 수정 (👍/💩)
* 챔피언 - 라인 필터 제거
* 인기 배지 높이 수정
* 모바일 정렬 헤더를 PC와 동일한 형태로 개선

### 🎮 매치 상세 / 최근 전적

* 매치 상세 표 레이아웃 개선(챔피언명 제거, 컬럼 조정, 빌드 아이콘 확대)
* 화면이 부모 영역을 넘지 않도록 수정하고 태블릿 화면 대응
* 최근 전적 무한 스크롤 적용(초기 10개 표시)
* 닉네임 우클릭 새 탭 열기 및 말줄임 표시 복구
* 팀워크 컴포넌트 기본 정렬을 판수순으로 변경

### 🤝 상대전적 (H2H)

* 라이벌 히스토리 그래프의 모바일 가독성 개선(가로 스크롤, 양쪽 페이드, 화살표 힌트, 점 간격 조정)
* 매치업 상세 행 모바일 레이아웃 개선, 헤더 2줄 분리, 승패 막대 색상 구분

### 📼 리플레이 업로드

* 업로드 화면 리디자인
* 로그명 복사 버튼 추가

### 🧑 소환사 챔피언 탭

* 라인 비중을 선택한 기간 기준으로 다시 계산하도록 변경
* 라인 필터에도 비중 표시 추가

### ✨ 애니메이션 / 인터랙션

* 매치 상세와 H2H 아코디언에 부드러운 펼침 애니메이션 적용
* 더보기 항목에 순차적으로 나타나는 fade-up 애니메이션 적용


## 프리뷰

<img width="1098" height="901" alt="image" src="https://github.com/user-attachments/assets/1476dd28-c530-487b-a8a7-b545ab092c92" />
<img width="363" height="526" alt="image" src="https://github.com/user-attachments/assets/f9998770-0430-42b3-afbd-d965c8e3cda3" />
<img width="1091" height="401" alt="image" src="https://github.com/user-attachments/assets/d5d14e9a-14a4-4af9-9abf-367a2a15231d" />
<img width="1095" height="419" alt="image" src="https://github.com/user-attachments/assets/36ab7aec-0637-4e29-8297-a0229f2fdd95" />
<img width="1103" height="435" alt="image" src="https://github.com/user-attachments/assets/f26cf1eb-9fc2-47ac-9289-1122be3e1c8c" />
<img width="1098" height="364" alt="image" src="https://github.com/user-attachments/assets/dd324f13-0e6c-4f41-b693-5ead8f4f125d" />
<img width="1102" height="968" alt="image" src="https://github.com/user-attachments/assets/0331f7dc-a0bd-4940-9e20-042a9663cca2" />
<img width="359" height="887" alt="image" src="https://github.com/user-attachments/assets/8b01fc63-9cd8-4739-9ee1-d657f1b0b3a3" />
