### PR TITLE
TRC-236 길드 목록 API 중복 호출 감소

### DIFF
--- a/src/hooks/auth/useGuildManagement.ts
+++ b/src/hooks/auth/useGuildManagement.ts
@@ -12,7 +12,8 @@ const useGuildManagement = () => {
   const { data: guildsData, isLoading: isLoadingGuilds } = useQuery<ApiResponse<GuildsResponse>>({
     queryKey: ["guilds"],
     queryFn: () => getGuilds(),
-    staleTime: 60 * 1000,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
   });
 
   const { data: meData } = useQuery<ApiResponse<MeResponse>>({


### PR DESCRIPTION
## 배경

거의 모든 페이지에서 `useGuildManagement`를 통해 `/api/auth/gmokGuilds`를 호출하고 있습니다. 현재 `staleTime: 60초`와 `refetchOnWindowFocus(true)` 설정으로 인해 페이지 이동이나 탭 복귀 시 API가 반복 호출됩니다.

이 API는 단순 조회가 아니라 호출마다 백엔드에서 Discord 외부 API 호출(레이트리밋 대상)과 DB Write 2종(기본 권한 보정, 닉네임 upsert)을 수행하므로, 프론트의 호출 횟수가 곧 백엔드 부하로 이어집니다.

## 변경 사항

`src/hooks/auth/useGuildManagement.ts`의 길드 조회 쿼리에만 적용합니다.

- `staleTime`: 60초 → 5분
- `refetchOnWindowFocus`: `false`

## 범위 밖

- 백엔드 로직 변경 없음(권한 보정·닉네임 upsert는 기존과 동일하게 길드 조회 시 수행)
- 전역 `QueryClient` 기본 설정은 변경하지 않음
- `me`, 전적, 통계 등 다른 React Query는 기존 동작 유지

## 기대 효과

(query-core 5.100.5 헤드리스 10분 세션 실측)

| 사용 패턴 | 현재 | 개선 후 | 감소 |
| --- | ---: | ---: | ---: |
| 활발히 페이지 이동 | 8회 | 2회 | 약 75% ↓ |
| 배경 탭 켜두고 오가기 | 7회 | 1회 | 약 86% ↓ |

## 유일한 동작 변화

세션 중 새 Discord 길드에 가입한 경우 길드 드롭다운 반영이 최대 5분 지연될 수 있습니다.

다만 새로고침 또는 재로그인 시 즉시 반영되며, 백엔드의 기본 권한 보정은 길드 조회 시 기존과 동일하게 수행되므로 기능상의 영향은 없습니다.