### PR TITLE
[Hotfix] TRC-238 챔피언 분석 라인 필터 복구

### DIFF
--- a/src/pages/champion/index.tsx
+++ b/src/pages/champion/index.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef, useMemo, useCallback } from "react"
 import useUserSearchController from "@/hooks/searchUserList/useUserSearchController";
 import useGuildManagement from "@/hooks/auth/useGuildManagement";
 import TitleBox from "@/components/ui/TitleBox";
+import PositionFilter from "@/features/statistics/PositionFilter";
 import ChampionRankHeader from "@/features/statistics/ChampionRankHeader";
 import ChampionRankItem from "@/features/statistics/ChampionRankItem";
 import { useQuery } from "@tanstack/react-query";
@@ -44,8 +45,7 @@ const SELECT_CLASS =
 
 const Champion: NextPage = () => {
   const [searchTerm, setSearchTerm] = useState("");
-  // 라인 필터 제거 — 항상 전체(ALL) 기준으로 조회한다.
-  const selectedPosition: Position = "ALL";
+  const [selectedPosition, setSelectedPosition] = useState<Position>("ALL");
   const [displayCount, setDisplayCount] = useState(10);
   const [sortBy, setSortBy] = useState<SortBy>("winRate");
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
@@ -299,7 +299,13 @@ const Champion: NextPage = () => {
         )}
       </div>
 
-      <div className="mt-4">
+      <PositionFilter
+        selectedPosition={selectedPosition}
+        onSelectPosition={setSelectedPosition}
+        className="mt-4"
+      />
+
+      <div className="mt-1">
         <ChampionRankHeader sortBy={sortBy} sortOrder={sortOrder} onSort={handleSort} />
         <div key={selectedPosition} className="space-y-3 mt-2">
           {(() => {


### PR DESCRIPTION
전일 디자인 개선 건 논의 과정에서 잘못 이해하는 바람에, 디자인 개선(TRC-234) 과정에서 챔피언 분석 페이지(`/champion`)의 라인 필터가 제거된 상태로 프로덕션에 배포되었습니다.

### 수정 사항

이전과 같이 유저 분석 페이지(`/user`)와 동일한 방식으로 라인 필터 UI를 복구했습니다.

<img width="544" height="391" alt="image" src="https://github.com/user-attachments/assets/a986ef74-9edb-4aa7-bcdb-21a3ef2fb1f3" />
