### PR TITLE
hotfix - 업로드 권한 관리 설명 문구에 삭제 권한 포함 명시

### DIFF
--- a/src/pages/clan/upload.tsx
+++ b/src/pages/clan/upload.tsx
@@ -366,7 +366,7 @@ const ClanUploadPage: NextPageWithLayout = () => <UploadPermissionContent />;
 ClanUploadPage.getLayout = (page) => (
   <ClanManageLayout
     title="업로드 권한 관리"
-    description="Discord 멤버에게 리플레이 업로더 권한을 부여·회수합니다."
+    description="Discord 멤버에게 업로더 권한을 부여·회수합니다. 업로더 권한이 있으면 리플레이 업로드와 삭제가 가능합니다."
   >
     {page}
   </ClanManageLayout>


### PR DESCRIPTION
업로더 권한이 업로드뿐 아니라 리플레이 삭제까지 가능함을 안내 문구에 반영